### PR TITLE
Add matrix and vector translation code

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,4 +20,10 @@ there.
 Below, a brief summary of patches made since the previous version can be found.
 
 ### v0.0.7
-- What's been added?
+- Index system translations
+  - Works with [caf.space](https://github.com/Transport-for-the-North/caf.space)
+  - Can take either pandas or numpy
+  - Matrix or vectors
+  - Weighted or direct translations
+  - When the memory is available, will perform fast translations
+    - Will fall back to a slower method when memory not available

--- a/src/caf/toolkit/toolbox.py
+++ b/src/caf/toolkit/toolbox.py
@@ -136,7 +136,7 @@ def get_missing_items(list_a: list[_T], list_b: list[_T]) -> tuple[list[_T], lis
     set_b = set(list_b)
     a_not_b = set_a - set_b
     b_not_a = set_b - set_a
-    return a_not_b, b_not_a
+    return list(a_not_b), list(b_not_a)
 
 
 # TODO(BT): Can this take a Collection instead?
@@ -154,4 +154,4 @@ def is_unique_list(unique_vals: list[Any]) -> bool:
         True if the list does not contain any duplicates. Otherwise False.
 
     """
-    return len(unique_vals) < len(set(unique_vals))
+    return len(unique_vals) == len(set(unique_vals))

--- a/src/caf/toolkit/toolbox.py
+++ b/src/caf/toolkit/toolbox.py
@@ -141,7 +141,7 @@ def get_missing_items(list_a: list[_T], list_b: list[_T]) -> tuple[list[_T], lis
 
 # TODO(BT): Can this take a Collection instead?
 def is_unique_list(unique_vals: list[Any]) -> bool:
-    """Check whether a list contains unique values only
+    """Check whether a list contains unique values only.
 
     Parameters
     ----------

--- a/src/caf/toolkit/toolbox.py
+++ b/src/caf/toolkit/toolbox.py
@@ -5,6 +5,7 @@ Most of these tools will be used elsewhere in the codebase too
 """
 # Built-Ins
 from typing import Any
+from typing import TypeVar
 from typing import Iterable
 
 # Third Party
@@ -15,6 +16,7 @@ from typing import Iterable
 # pylint: enable=import-error,wrong-import-position
 
 # # # CONSTANTS # # #
+_T = TypeVar("_T")
 
 # # # CLASSES # # #
 
@@ -109,3 +111,47 @@ def equal_ignore_order(one: Iterable[Any], two: Iterable[Any]) -> bool:
         except ValueError:
             return False
     return not unmatched
+
+
+def get_missing_items(list_a: list[_T], list_b: list[_T]) -> tuple[list[_T], list[_T]]:
+    """Get a list of the items in each list, but not the other.
+
+    Parameters
+    ----------
+    list_a:
+        The first list to check.
+
+    list_b
+        The second list to check.
+
+    Returns
+    -------
+    a_not_b:
+        A list of the items in `list_a` but not `list_b`.
+
+    b_not_a:
+        A list of the items in `list_b` but not `list_a`.
+    """
+    set_a = set(list_a)
+    set_b = set(list_b)
+    a_not_b = set_a - set_b
+    b_not_a = set_b - set_a
+    return a_not_b, b_not_a
+
+
+# TODO(BT): Can this take a Collection instead?
+def is_unique_list(unique_vals: list[Any]) -> bool:
+    """Check whether a list contains unique values only
+
+    Parameters
+    ----------
+    unique_vals:
+        The list of unique values to validate.
+
+    Returns
+    -------
+    is_unique:
+        True if the list does not contain any duplicates. Otherwise False.
+
+    """
+    return len(unique_vals) < len(set(unique_vals))

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tools to convert numpy/pandas vectors/matrices between different index systems
+"""Tools to convert numpy/pandas vectors/matrices between different index systems.
 
 In transport, these tools are very useful for translating data between different
 zoning systems.
@@ -12,6 +12,7 @@ import warnings
 
 from typing import Any
 from typing import TypeVar
+from typing import Optional
 
 # Third Party
 import numpy as np
@@ -40,7 +41,7 @@ def _lower_memory_row_translation(
     vector_chunk: np.ndarray,
     row_translation: np.ndarray,
 ) -> np.ndarray:
-    """Internal MP functionality of _lower_memory_matrix_zone_translation()"""
+    """Run internal functionality of _lower_memory_matrix_zone_translation()."""
     # Translate the rows
     row_translated = list()
     for vector in np.hsplit(vector_chunk, vector_chunk.shape[1]):
@@ -57,7 +58,7 @@ def _lower_memory_col_translation(
     vector_chunk: np.ndarray,
     col_translation: np.ndarray,
 ) -> np.ndarray:
-    """Internal MP functionality of _lower_memory_matrix_zone_translation()"""
+    """Run internal functionality of _lower_memory_matrix_zone_translation()."""
     # Translate the columns
     col_translated = list()
     for vector in np.vsplit(vector_chunk, vector_chunk.shape[0]):
@@ -83,7 +84,7 @@ def _lower_memory_matrix_zone_translation(
     kwargs = list()
     n_splits = matrix.shape[1] / chunk_size
     n_splits = 1 if n_splits <= 0 else n_splits
-    for vector_chunk in np.array_split(matrix, n_splits, axis=1):
+    for vector_chunk in np.array_split(matrix, n_splits, axis=1):   # type: ignore
         kwargs.append(
             {
                 "vector_chunk": vector_chunk,
@@ -104,7 +105,7 @@ def _lower_memory_matrix_zone_translation(
     kwargs = list()
     n_splits = row_translated.shape[0] / chunk_size
     n_splits = 1 if n_splits <= 0 else n_splits
-    for vector_chunk in np.array_split(row_translated, n_splits, axis=0):
+    for vector_chunk in np.array_split(row_translated, n_splits, axis=0):   # type: ignore
         kwargs.append(
             {
                 "vector_chunk": vector_chunk,
@@ -164,7 +165,7 @@ def _convert_dtypes(
     to_type: np.dtype,
     arr_name: str = "arr",
 ) -> np.ndarray:
-    """Convert a numpy array to a different datatype"""
+    """Convert a numpy array to a different datatype."""
     # Shortcut if already matching
     if to_type == arr.dtype:
         return arr
@@ -173,6 +174,8 @@ def _convert_dtypes(
     mat_max = np.max(arr)
     mat_min = np.min(arr)
 
+    dtype_max: np.floating | int
+    dtype_min: np.floating | int
     if np.issubdtype(to_type, np.floating):
         dtype_max = np.finfo(to_type).max
         dtype_min = np.finfo(to_type).min
@@ -205,14 +208,14 @@ def _convert_dtypes(
 def numpy_matrix_zone_translation(
     matrix: np.ndarray,
     translation: np.ndarray,
-    col_translation: np.ndarray = None,
-    translation_dtype: np.dtype = None,
+    col_translation: Optional[np.ndarray] = None,
+    translation_dtype: Optional[np.dtype] = None,
     check_shapes: bool = True,
     check_totals: bool = True,
     slow_fallback: bool = True,
     chunk_size: int = 100,
 ) -> np.ndarray:
-    """Efficiently translates a matrix between index systems
+    """Efficiently translates a matrix between index systems.
 
     Uses the given translation matrices to translate a matrix of values
     from one index system to another. This has been written in pure numpy
@@ -377,11 +380,11 @@ def numpy_matrix_zone_translation(
 def numpy_vector_zone_translation(
     vector: np.ndarray,
     translation: np.ndarray,
-    translation_dtype: np.dtype = None,
+    translation_dtype: Optional[np.dtype] = None,
     check_shapes: bool = True,
     check_totals: bool = True,
 ) -> np.ndarray:
-    """Efficiently translates a vector between index systems
+    """Efficiently translates a vector between index systems.
 
     Uses the given translation matrix to translate a vector of values from one
     index system to another. This has been written in pure numpy operations.
@@ -505,14 +508,14 @@ def pandas_matrix_zone_translation(
     to_unique_index: list[Any],
     translation: pd.DataFrame,
     col_translation: pd.DataFrame = None,
-    translation_dtype: np.dtype = None,
+    translation_dtype: Optional[np.dtype] = None,
     matrix_infill: float = 0.0,
     translate_infill: float = 0.0,
     check_totals: bool = True,
     slow_fallback: bool = True,
     chunk_size: int = 100,
 ) -> pd.DataFrame:
-    """Efficiently translates a pandas matrix between index systems
+    """Efficiently translates a pandas matrix between index systems.
 
     Parameters
     ----------
@@ -697,13 +700,13 @@ def pandas_vector_zone_translation(
     translation_factors_col: str,
     from_unique_index: list[Any],
     to_unique_index: list[Any],
-    translation_dtype: np.dtype = None,
+    translation_dtype: Optional[np.dtype] = None,
     vector_infill: float = 0.0,
     translate_infill: float = 0.0,
     check_totals: bool = True,
 ) -> pd.Series:
     # pylint: disable=too-many-arguments
-    """Efficiently translates a pandas vector between index systems
+    """Efficiently translates a pandas vector between index systems.
 
     Internally, checks and converts the pandas inputs into numpy arrays
     and calls `numpy_vector_zone_translation()`. The final output is then

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -214,6 +214,7 @@ def numpy_matrix_zone_translation(
     check_totals: bool = True,
     slow_fallback: bool = True,
     chunk_size: int = 100,
+    _force_slow: bool = False,
 ) -> np.ndarray:
     """Efficiently translates a matrix between index systems.
 

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -776,9 +776,8 @@ def pandas_vector_zone_translation(
     # Check the matrix and translation dtypes match
     if vector.index.dtype != translation[translation_from_col].dtype:
         raise ValueError(
-            f"The datatype of the vector index must be the same as the "
-            f"translation datatype in from_zone_col for the zone "
-            f"translation to work.\n"
+            "dtypes of `vector.index` and `translation` in `from_zone_col` "
+            "must match.\n"
             f"vector index data type: {vector.index.dtype}\n"
             f"translation[from_zone_col] data type: {translation[translation_from_col].dtype}"
         )
@@ -790,19 +789,19 @@ def pandas_vector_zone_translation(
     missing_rows = set(vector.index.to_list()) - set(from_unique_index)
     if len(missing_rows) > 0:
         warnings.warn(
-            f"Some zones in vector.index have not been defined in "
-            f"from_unique_zones. These zones will be dropped before "
+            f"Some zones in `vector.index` have not been defined in "
+            f"`from_unique_zones`. These zones will be dropped before "
             f"translating.\n"
             f"Additional rows count: {len(missing_rows)}"
         )
 
-    # Check all needed values are in from_zone_col zone col
+    # Check all needed values are in from_zone_col
     trans_from_zones = set(translation[translation_from_col].unique())
     missing_zones = set(from_unique_index) - trans_from_zones
     if len(missing_zones) != 0:
         warnings.warn(
-            f"Some zones in vector.index are missing in the translation. "
-            f"Infilling missing zones with translation infill.\n"
+            f"Some zones in `vector.index` are missing in `translation`. "
+            f"Infilling missing zones with `translation_infill`.\n"
             f"Missing zones count: {len(missing_zones)}"
         )
 

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -290,6 +290,8 @@ def numpy_matrix_zone_translation(
     if col_translation is None:
         col_translation = translation.copy()
 
+    slow_fallback = True if _force_slow else slow_fallback
+
     # ## OPTIONALLY CHECK INPUT SHAPES ## #
     if check_shapes:
         _check_matrix_translation_shapes(
@@ -325,6 +327,10 @@ def numpy_matrix_zone_translation(
 
     # If matrix is big enough, we might run out of memory
     try:
+        # Force except
+        if _force_slow:
+            raise MemoryError
+
         # Translate rows
         mult_shape = (n_in, n_in, n_out)
         expanded_rows = np.broadcast_to(np.expand_dims(matrix, axis=2), mult_shape)

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -608,6 +608,21 @@ def pandas_matrix_zone_translation(
     if col_translation is None:
         col_translation = translation.copy()
 
+    # Make sure columns exist in the translations
+    columns= [translation_from_col, translation_to_col, translation_factors_col]
+    row_translation = pd_utils.reindex_cols(
+        df=row_translation,
+        columns=columns,
+        throw_error=True,
+        dataframe_name="row_translation"
+    )
+    col_translation = pd_utils.reindex_cols(
+        df=col_translation,
+        columns=columns,
+        throw_error=True,
+        dataframe_name="col_translation"
+    )
+
     # Check the matrix and translation dtypes match
     if matrix.index.dtype != row_translation[translation_from_col].dtype:
         raise ValueError(

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -171,8 +171,15 @@ def _convert_dtypes(
     # Make sure we're not going to introduce infs...
     mat_max = np.max(arr)
     mat_min = np.min(arr)
-    dtype_max = np.finfo(to_type).max
-    dtype_min = np.finfo(to_type).min
+
+    if np.issubdtype(to_type, np.floating):
+        dtype_max = np.finfo(to_type).max
+        dtype_min = np.finfo(to_type).min
+    elif np.issubdtype(to_type, np.integer):
+        dtype_max = np.iinfo(to_type).max
+        dtype_min = np.iinfo(to_type).min
+    else:
+        raise ValueError(f"Don't know how to get min/max info for datatype: {to_type}")
 
     if mat_max > dtype_max:
         raise ValueError(

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -97,6 +97,7 @@ def _lower_memory_matrix_zone_translation(
         kwarg_list=kwargs,
         process_count=process_count,
         in_order=True,
+        pbar_kwargs={"desc": "Translating rows"},
     )
 
     row_translated = np.vstack(row_translated).T
@@ -118,6 +119,7 @@ def _lower_memory_matrix_zone_translation(
         kwarg_list=kwargs,
         process_count=process_count,
         in_order=True,
+        pbar_kwargs={"desc": "Translating columns"},
     )
 
     return np.vstack(full_translated)
@@ -611,10 +613,16 @@ def pandas_matrix_zone_translation(
     # Make sure columns exist in the translations
     columns = [translation_from_col, translation_to_col, translation_factors_col]
     row_translation = pd_utils.reindex_cols(
-        df=row_translation, columns=columns, throw_error=True, dataframe_name="row_translation"
+        df=row_translation,
+        columns=columns,
+        throw_error=True,
+        dataframe_name="row_translation",
     )
     col_translation = pd_utils.reindex_cols(
-        df=col_translation, columns=columns, throw_error=True, dataframe_name="col_translation"
+        df=col_translation,
+        columns=columns,
+        throw_error=True,
+        dataframe_name="col_translation",
     )
 
     # Check the matrix and translation dtypes match

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -4,6 +4,8 @@
 In transport, these tools are very useful for translating data between different
 zoning systems.
 """
+from __future__ import annotations
+
 # Built-Ins
 import logging
 import warnings
@@ -688,7 +690,7 @@ def pandas_matrix_zone_translation(
 
 
 def pandas_vector_zone_translation(
-    vector: pd.Series,
+    vector: pd.Series | pd.DataFrame,
     translation: pd.DataFrame,
     translation_from_col: str,
     translation_to_col: str,
@@ -762,6 +764,15 @@ def pandas_vector_zone_translation(
     --------
     .numpy_vector_zone_translation()
     """
+    # If dataframe given, try coerce
+    if isinstance(vector, pd.DataFrame):
+        if vector.shape[1] != 1:
+            raise ValueError(
+                "`vector` must be a pandas.Series, or a pandas.DataFrame with "
+                f"one column. Got a DataFrame of shape {vector.shape} instead"
+            )
+        vector = vector[vector.columns[0]]
+
     # Check the matrix and translation dtypes match
     if vector.index.dtype != translation[translation_from_col].dtype:
         raise ValueError(

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -609,18 +609,12 @@ def pandas_matrix_zone_translation(
         col_translation = translation.copy()
 
     # Make sure columns exist in the translations
-    columns= [translation_from_col, translation_to_col, translation_factors_col]
+    columns = [translation_from_col, translation_to_col, translation_factors_col]
     row_translation = pd_utils.reindex_cols(
-        df=row_translation,
-        columns=columns,
-        throw_error=True,
-        dataframe_name="row_translation"
+        df=row_translation, columns=columns, throw_error=True, dataframe_name="row_translation"
     )
     col_translation = pd_utils.reindex_cols(
-        df=col_translation,
-        columns=columns,
-        throw_error=True,
-        dataframe_name="col_translation"
+        df=col_translation, columns=columns, throw_error=True, dataframe_name="col_translation"
     )
 
     # Check the matrix and translation dtypes match

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -1,0 +1,818 @@
+# -*- coding: utf-8 -*-
+"""Tools to convert numpy/pandas vectors/matrices between different index systems
+
+In transport, these tools are very useful for translating data between different
+zoning systems.
+"""
+# Built-Ins
+import logging
+import warnings
+
+from typing import Any
+from typing import TypeVar
+
+# Third Party
+import numpy as np
+import pandas as pd
+
+# Local Imports
+# pylint: disable=import-error,wrong-import-position
+from caf.toolkit import validators
+from caf.toolkit import math_utils
+from caf.toolkit import concurrency
+from caf.toolkit import pandas_utils as pd_utils
+
+# pylint: enable=import-error,wrong-import-position
+
+# # # CONSTANTS # # #
+_T = TypeVar("_T")
+
+LOG = logging.getLogger(__name__)
+
+# # # CLASSES # # #
+
+
+# # # FUNCTIONS # # #
+# ## PRIVATE FUNCTIONS ## #
+def _lower_memory_row_translation(
+    vector_chunk: np.ndarray,
+    row_translation: np.ndarray,
+) -> np.ndarray:
+    """Internal MP functionality of _lower_memory_matrix_zone_translation()"""
+    # Translate the rows
+    row_translated = list()
+    for vector in np.hsplit(vector_chunk, vector_chunk.shape[1]):
+        vector = vector.flatten()
+        vector = np.broadcast_to(np.expand_dims(vector, axis=1), row_translation.shape)
+        vector = vector * row_translation
+        vector = vector.sum(axis=0)
+        row_translated.append(vector)
+
+    return np.array(row_translated)
+
+
+def _lower_memory_col_translation(
+    vector_chunk: np.ndarray,
+    col_translation: np.ndarray,
+) -> np.ndarray:
+    """Internal MP functionality of _lower_memory_matrix_zone_translation()"""
+    # Translate the columns
+    col_translated = list()
+    for vector in np.vsplit(vector_chunk, vector_chunk.shape[0]):
+        vector = vector.flatten()
+        vector = np.broadcast_to(np.expand_dims(vector, axis=1), col_translation.shape)
+        vector = vector * col_translation
+        vector = vector.sum(axis=0)
+        col_translated.append(vector)
+
+    return np.array(col_translated)
+
+
+def _lower_memory_matrix_zone_translation(
+    matrix: np.ndarray,
+    row_translation: np.ndarray,
+    col_translation: np.ndarray,
+    chunk_size: int,
+    process_count: int = -2,
+) -> np.ndarray:
+    # TODO(BT): Can numba be used here to speed this
+    #  up instead of multiprocessing??
+    # Translate the rows
+    kwargs = list()
+    n_splits = matrix.shape[1] / chunk_size
+    n_splits = 1 if n_splits <= 0 else n_splits
+    for vector_chunk in np.array_split(matrix, n_splits, axis=1):
+        kwargs.append(
+            {
+                "vector_chunk": vector_chunk,
+                "row_translation": row_translation,
+            }
+        )
+
+    row_translated = concurrency.multiprocess(
+        fn=_lower_memory_row_translation,
+        kwarg_list=kwargs,
+        process_count=process_count,
+        in_order=True,
+    )
+
+    row_translated = np.vstack(row_translated).T
+
+    # Translate the rows
+    kwargs = list()
+    n_splits = row_translated.shape[0] / chunk_size
+    n_splits = 1 if n_splits <= 0 else n_splits
+    for vector_chunk in np.array_split(row_translated, n_splits, axis=0):
+        kwargs.append(
+            {
+                "vector_chunk": vector_chunk,
+                "col_translation": col_translation,
+            }
+        )
+
+    full_translated = concurrency.multiprocess(
+        fn=_lower_memory_col_translation,
+        kwarg_list=kwargs,
+        process_count=process_count,
+        in_order=True,
+    )
+
+    return np.vstack(full_translated)
+
+
+def _check_matrix_translation_shapes(
+    matrix: np.ndarray,
+    row_translation: np.ndarray,
+    col_translation: np.ndarray,
+) -> None:
+    # Check matrix is square
+    mat_rows, mat_columns = matrix.shape
+    if mat_rows != mat_columns:
+        raise ValueError(
+            f"The given matrix is not square. Matrix needs to be square "
+            f"for the numpy zone translations to work.\n"
+            f"Given matrix shape: {str(matrix.shape)}"
+        )
+
+    # Check translations are the same shape
+    if row_translation.shape != col_translation.shape:
+        raise ValueError(
+            f"Row and column translations are not the same shape. Both "
+            f"need to be (n_in, n_out) shape for numpy zone translations "
+            f"to work.\n"
+            f"Row shape: {row_translation.shape}\n"
+            f"Column shape: {col_translation.shape}"
+        )
+
+    # Check translation has the right number of rows
+    n_zones_in, _ = row_translation.shape
+    if n_zones_in != mat_rows:
+        raise ValueError(
+            f"The given translation does not have the correct number of "
+            f"rows. Translation rows needs to match matrix rows for the "
+            f"numpy zone translations to work.\n"
+            f"Given matrix shape: {matrix.shape}\n"
+            f"Given translation shape: {row_translation.shape}"
+        )
+
+
+# TODO(BT): Move to numpy_utils??
+#  Would mean making array_utils sparse specific
+def _convert_dtypes(
+    arr: np.ndarray,
+    to_type: np.dtype,
+    arr_name: str = "arr",
+) -> np.ndarray:
+    """Convert a numpy array to a different datatype"""
+    # Shortcut if already matching
+    if to_type == arr.dtype:
+        return arr
+
+    # Make sure we're not going to introduce infs...
+    mat_max = np.max(arr)
+    mat_min = np.min(arr)
+    dtype_max = np.finfo(to_type).max
+    dtype_min = np.finfo(to_type).min
+
+    if mat_max > dtype_max:
+        raise ValueError(
+            f"The maximum value of {to_type} cannot handle the maximum value "
+            f"found in {arr_name}.\n"
+            f"Maximum dtype value: {dtype_max}\n"
+            f"Maximum {arr_name} value: {mat_max}"
+        )
+
+    if mat_min < dtype_min:
+        raise ValueError(
+            f"The minimum value of {to_type} cannot handle the minimum value "
+            f"found in {arr_name}.\n"
+            f"Minimum dtype value: {dtype_max}\n"
+            f"Minimum {arr_name} value: {mat_max}"
+        )
+
+    return arr.astype(to_type)
+
+
+# ## PUBLIC FUNCTIONS ## #
+def numpy_matrix_zone_translation(
+    matrix: np.ndarray,
+    translation: np.ndarray,
+    col_translation: np.ndarray = None,
+    translation_dtype: np.dtype = None,
+    check_shapes: bool = True,
+    check_totals: bool = False,
+    slow_fallback: bool = True,
+    chunk_size: int = 100,
+) -> np.ndarray:
+    """Efficiently translates a matrix between index systems
+
+    Uses the given translation matrices to translate a matrix of values
+    from one index system to another. This has been written in pure numpy
+    operations.
+    NOTE:
+    The algorithm optimises for speed by expanding the translation across
+    3 dimensions. For large matrices this can result in `MemoryError`. In
+    these cases the algorithm will fall back to a slower, more memory
+    efficient algorithm when `slow_fallback` is `True`. `translation_dtype`
+    can be set to a smaller data type, sacrificing accuracy for speed.
+
+    Parameters
+    ----------
+    matrix:
+        The matrix to translate. Must be square.
+        e.g. (n_in, n_in)
+
+    translation:
+        A matrix defining the weights to use to translate.
+        Should be of shape (n_in, n_out), where the output
+        matrix shape will be (n_out, n_out). A value of `0.5` in
+        `translation[0, 2]` Would mean that
+        50% of the value in index 0 of `vector` should end up in index 2 of
+        the output.
+        When `col_translation` is None, this defines the translation to use
+        for both the rows and columns. When `col_translation` is set, this
+        defines the translation to use for the rows.
+
+    col_translation:
+        A matrix defining the weights to use to translate the columns.
+        Takes an input of the same format as `translation`. When None,
+        `translation` is used as the column translation.
+
+    translation_dtype:
+        The numpy datatype to use to do the translation. If None, then the
+        dtype of the matrix is used. Where such high precision
+        isn't needed, a more memory and time efficient data type can be used.
+
+    check_shapes:
+        Whether to check that the input and translation shapes look correct.
+        Optionally set to `False` if checks have been done externally to speed
+        up runtime.
+
+    check_totals:
+        Whether to check that the input and output matrices sum to the same
+        total.
+
+    slow_fallback:
+        Whether to fall back to a slower, more memory efficient method if a
+        `MemoryError` is raised during faster translation.
+
+    chunk_size:
+        The size of the chunks to use if falling back on a slower, more memory
+        efficient method. Most of the time this can be ignored unless
+        translating between two massive zoning systems.
+
+    Returns
+    -------
+    translated_matrix:
+        matrix, translated into (n_out, n_out) shape via translation.
+
+    Raises
+    ------
+    ValueError:
+        Will raise an error if matrix is not a square array, or if translation
+        does not have the same number of rows as matrix.
+    """
+    # pylint: disable=too-many-locals
+    # Init
+    row_translation = translation
+    if col_translation is None:
+        col_translation = translation.copy()
+
+    # ## OPTIONALLY CHECK INPUT SHAPES ## #
+    if check_shapes:
+        _check_matrix_translation_shapes(
+            matrix=matrix,
+            row_translation=row_translation,
+            col_translation=col_translation,
+        )
+
+    # ## CONVERT DTYPES ## #
+    if translation_dtype is None:
+        translation_dtype = matrix.dtype
+    matrix = _convert_dtypes(
+        arr=matrix,
+        to_type=translation_dtype,
+        arr_name="matrix",
+    )
+    row_translation = _convert_dtypes(
+        arr=row_translation,
+        to_type=translation_dtype,
+        arr_name="row_translation",
+    )
+    col_translation = _convert_dtypes(
+        arr=col_translation,
+        to_type=translation_dtype,
+        arr_name="col_translation",
+    )
+
+    # ## DO THE TRANSLATION ## #
+    not_enough_memory = False
+    translated_matrix = None
+    n_in, n_out = row_translation.shape
+
+    # If matrix is big enough, we might run out of memory
+    try:
+        # Translate rows
+        mult_shape = (n_in, n_in, n_out)
+        expanded_rows = np.broadcast_to(np.expand_dims(matrix, axis=2), mult_shape)
+        row_trans = np.broadcast_to(np.expand_dims(row_translation, axis=1), mult_shape)
+        temp = expanded_rows * row_trans
+
+        # mat is transposed, but we need it this way
+        rows_done = temp.sum(axis=0)
+
+        # Translate cols
+        mult_shape = (n_in, n_out, n_out)
+        expanded_cols = np.broadcast_to(np.expand_dims(rows_done, axis=2), mult_shape)
+        col_trans = np.broadcast_to(np.expand_dims(col_translation, axis=1), mult_shape)
+        temp = expanded_cols * col_trans
+        translated_matrix = temp.sum(axis=0)
+
+    except MemoryError as err:
+        if not slow_fallback:
+            raise err
+        not_enough_memory = True
+
+    # Try translation again, a slower way.
+    if not_enough_memory:
+        warnings.warn(
+            "Ran out of memory during translation. Falling back to a slower, "
+            "more memory efficient method."
+        )
+        translated_matrix = _lower_memory_matrix_zone_translation(
+            matrix=matrix,
+            row_translation=row_translation,
+            col_translation=col_translation,
+            chunk_size=chunk_size,
+        )
+
+    # Ensure value has been set for MyPy
+    assert translated_matrix is not None
+
+    if not check_totals:
+        return translated_matrix
+
+    if not math_utils.is_almost_equal(matrix.sum(), translated_matrix.sum()):
+        raise ValueError(
+            f"Some values seem to have been dropped during the translation. "
+            f"Check the given translation matrix isn't unintentionally "
+            f"dropping values. If the difference is small, it's likely a "
+            f"rounding error.\n"
+            f"Before: {matrix.sum()}\n"
+            f"After: {translated_matrix.sum()}"
+        )
+
+    return translated_matrix
+
+
+def numpy_vector_zone_translation(
+    vector: np.ndarray,
+    translation: np.ndarray,
+    translation_dtype: np.dtype = None,
+    check_shapes: bool = True,
+    check_totals: bool = False,
+) -> np.ndarray:
+    """Efficiently translates a vector between index systems
+
+    Uses the given translation matrix to translate a vector of values from one
+    index system to another. This has been written in pure numpy operations.
+    This algorithm optimises for speed by expanding the translation across 2
+    dimensions. For large vectors this can result in `MemoryError`. If
+    this happens, the `translation_dtype` needs to be set to a smaller data
+    type, sacrificing accuracy.
+
+    Parameters
+    ----------
+    vector:
+        The vector to translate. Must be one dimensional.
+        e.g. (n_in, )
+
+    translation:
+        The matrix defining the weights to use to translate matrix. Should
+        be of shape (n_in, n_out), where the output vector shape will be
+        (n_out, ). A value of `0.5` in `translation[0, 2]` Would mean that
+        50% of the value in index 0 of `vector` should end up in index 2 of
+        the output.
+
+    translation_dtype:
+        The numpy datatype to use to do the translation. If None, then the
+        dtype of the vector is used. Where such high precision
+        isn't needed, a more memory and time efficient data type can be used.
+
+    check_shapes:
+        Whether to check that the input and translation shapes look correct.
+        Optionally set to False if checks have been done externally to speed
+        up runtime.
+
+    check_totals:
+        Whether to check that the input and output vectors sum to the same
+        total.
+
+    Returns
+    -------
+    translated_vector:
+        vector, translated into (n_out, ) shape via translation.
+
+    Raises
+    ------
+    ValueError:
+        Will raise an error if `vector` is not a 1d array, or if `translation`
+        does not have the same number of rows as vector.
+    """
+    # ## OPTIONALLY CHECK INPUT SHAPES ## #
+    if check_shapes:
+        # Check that vector is 1D
+        if len(vector.shape) > 1:
+            if vector.shape[1] == 1:
+                vector = vector.flatten()
+            else:
+                raise ValueError(
+                    f"The given vector is not a vector. Expected a np.ndarray "
+                    f"with only one dimension, but got {len(vector.shape)} "
+                    f"dimensions instead."
+                )
+
+        # Check translation has the right number of rows
+        n_zones_in, _ = translation.shape
+        if n_zones_in != len(vector):
+            raise ValueError(
+                f"The given translation does not have the correct number of "
+                f"rows. Translation rows needs to match vector rows for the "
+                f"numpy zone translations to work.\n"
+                f"Given vector shape: {vector.shape}\n"
+                f"Given translation shape: {translation.shape}"
+            )
+
+    # ## CONVERT DTYPES ## #
+    if translation_dtype is None:
+        translation_dtype = vector.dtype
+    vector = _convert_dtypes(
+        arr=vector,
+        to_type=translation_dtype,
+        arr_name="vector",
+    )
+    translation = _convert_dtypes(
+        arr=translation,
+        to_type=translation_dtype,
+        arr_name="translation",
+    )
+
+    # ## TRANSLATE ## #
+    out_vector = np.broadcast_to(np.expand_dims(vector, axis=1), translation.shape)
+    out_vector = out_vector * translation
+    out_vector = out_vector.sum(axis=0)
+
+    if not check_totals:
+        return out_vector
+
+    if not math_utils.is_almost_equal(vector.sum(), out_vector.sum()):
+        raise ValueError(
+            f"Some values seem to have been dropped during the translation. "
+            f"Check the given translation matrix isn't unintentionally "
+            f"dropping values. If the difference is small, it's "
+            f"likely a rounding error.\n"
+            f"Before: {vector.sum()}\n"
+            f"After: {out_vector.sum()}"
+        )
+
+    return out_vector
+
+
+def pandas_matrix_zone_translation(
+    matrix: pd.DataFrame,
+    translation_from_col: str,
+    translation_to_col: str,
+    translation_factors_col: str,
+    from_unique_index: list[Any],
+    to_unique_index: list[Any],
+    translation: pd.DataFrame,
+    col_translation: pd.DataFrame = None,
+    translation_dtype: np.dtype = None,
+    matrix_infill: float = 0.0,
+    translate_infill: float = 0.0,
+    check_totals: bool = False,
+    slow_fallback: bool = True,
+    chunk_size: int = 100,
+) -> pd.DataFrame:
+    """Efficiently translates a pandas matrix between index systems
+
+    Parameters
+    ----------
+    matrix:
+        The matrix to translate. The index and columns need to be the
+        values being translated. This CANNOT be a "long" matrix.
+
+    translation:
+        A pandas DataFrame defining the weights to translate use when
+        translating.
+        Needs to contain columns:
+        `translation_from_col`, `translation_to_col`, `translation_factors_col`.
+        When `col_translation` is None, this defines the translation to use
+        for both the rows and columns. When `col_translation` is set, this
+        defines the translation to use for the rows.
+
+    col_translation:
+        A matrix defining the weights to use to translate the columns.
+        Takes an input of the same format as `translation`. When None,
+        `translation` is used as the column translation.
+
+    translation_from_col:
+        The name of the column in `translation` and `col_translation`
+        containing the current index and column values of `matrix`.
+
+    translation_to_col:
+        The name of the column in `translation` and `col_translation`
+        containing the desired output index and column values. This
+        will define the output index and column format.
+
+    translation_factors_col:
+        The name of the column in `translation` and `col_translation`
+        containing the translation weights between `translation_from_col` and
+        `translation_to_col`. Where zone pairs do not exist, they will be
+        infilled with `translate_infill`.
+
+    from_unique_index:
+        A list of all the unique IDs in the input indexing system.
+
+    to_unique_index:
+        A list of all the unique IDs in the output indexing system.
+
+    translation_dtype:
+        The numpy datatype to use to do the translation. If None, then the
+        dtype of `vector` is used. Where such high precision
+        isn't needed, a more memory and time efficient data type can be used.
+
+    matrix_infill:
+        The value to use to infill any missing matrix values.
+
+    translate_infill:
+        The value to use to infill any missing translation factors.
+
+    check_totals:
+        Whether to check that the input and output matrices sum to the same
+        total.
+
+    slow_fallback:
+        Whether to fall back to a slower, more memory efficient method if a
+        `MemoryError` is raised during faster translation.
+
+    chunk_size:
+        The size of the chunks to use if falling back on a slower, more memory
+        efficient method. Most of the time this can be ignored unless
+        translating between two massive zoning systems.
+
+    Returns
+    -------
+    translated_matrix:
+        matrix, translated into to_unique_index system.
+
+    Raises
+    ------
+    ValueError:
+        If matrix is not a square array, or if translation any inputs are not
+        the correct format.
+    """
+    # pylint: disable=too-many-arguments, too-many-locals
+    # Init
+    row_translation = translation
+    if col_translation is None:
+        col_translation = translation.copy()
+
+    # Check the matrix and translation dtypes match
+    if matrix.index.dtype != row_translation[translation_from_col].dtype:
+        raise ValueError(
+            f"The datatype of the matrix index must be the same as the "
+            f"datatype of the row translation in translation_from_col for "
+            f"the zone translation to work.\n"
+            f"Matrix index data type: {matrix.index.dtype}\n"
+            f"Row Translation data type: {row_translation[translation_from_col].dtype}"
+        )
+
+    if matrix.columns.dtype != col_translation[translation_from_col].dtype:
+        raise ValueError(
+            f"The datatype of the matrix columns must be the same as the "
+            f"datatype of the column translation in translation_from_col for "
+            f"the zone translation to work.\n"
+            f"Matrix column Dtype: {matrix.columns.dtype}\n"
+            f"Col Translation data type: {col_translation[translation_from_col].dtype}"
+        )
+
+    validators.unique_list(from_unique_index, name="from_unique_index")
+    validators.unique_list(to_unique_index, name="to_unique_index")
+
+    # Make sure the matrix only has the zones defined in from_unique_zones
+    missing_rows = set(matrix.index.to_list()) - set(from_unique_index)
+    if len(missing_rows) > 0:
+        warnings.warn(
+            f"There are some zones in matrix.index that have not been "
+            f"defined in from_unique_zones. These zones will be dropped "
+            f"before the translation!\n"
+            f"Additional rows count: {len(missing_rows)}"
+        )
+
+    missing_cols = set(matrix.columns.to_list()) - set(from_unique_index)
+    if len(missing_cols) > 0:
+        warnings.warn(
+            f"There are some zones in matrix.columns that have not been "
+            f"defined in from_unique_zones. These zones will be dropped "
+            f"before the translation!\n"
+            f"Additional cols count: {len(missing_cols)}"
+        )
+
+    # ## PREP AND TRANSLATE ## #
+    # Square the translation
+    row_translation = pd_utils.long_to_wide_infill(
+        df=row_translation,
+        index_col=translation_from_col,
+        columns_col=translation_to_col,
+        values_col=translation_factors_col,
+        index_vals=from_unique_index,
+        column_vals=to_unique_index,
+        infill=translate_infill,
+    )
+
+    # Can speed up with translation is not None - row and col translations are same
+    if translation is not None:
+        col_translation = row_translation.copy()
+    else:
+        col_translation = pd_utils.long_to_wide_infill(
+            df=col_translation,
+            index_col=translation_from_col,
+            columns_col=translation_to_col,
+            values_col=translation_factors_col,
+            index_vals=from_unique_index,
+            column_vals=to_unique_index,
+            infill=translate_infill,
+        )
+
+    # Make sure all zones are in the matrix and infill 0s
+    matrix = matrix.reindex(
+        index=from_unique_index,
+        columns=from_unique_index,
+        fill_value=matrix_infill,
+    )
+
+    # Translate
+    translated = numpy_matrix_zone_translation(
+        matrix=matrix.values,
+        translation=row_translation.values,
+        col_translation=col_translation.values,
+        translation_dtype=translation_dtype,
+        check_totals=check_totals,
+        slow_fallback=slow_fallback,
+        chunk_size=chunk_size,
+    )
+
+    # Stick into pandas
+    return pd.DataFrame(
+        data=translated,
+        index=to_unique_index,
+        columns=to_unique_index,
+    )
+
+
+def pandas_vector_zone_translation(
+    vector: pd.Series,
+    translation: pd.DataFrame,
+    translation_from_col: str,
+    translation_to_col: str,
+    translation_factors_col: str,
+    from_unique_index: list[Any],
+    to_unique_index: list[Any],
+    translation_dtype: np.dtype = None,
+    vector_infill: float = 0.0,
+    translate_infill: float = 0.0,
+    check_totals: bool = False,
+) -> pd.Series:
+    # pylint: disable=too-many-arguments
+    """Efficiently translates a pandas vector between index systems
+
+    Internally, checks and converts the pandas inputs into numpy arrays
+    and calls `numpy_vector_zone_translation()`. The final output is then
+    converted back into a pandas Series, using the same format as the input.
+
+    Parameters
+    ----------
+    vector:
+        The vector to translate. The index must be the values to be translated.
+
+    translation:
+        A pandas DataFrame defining the weights to translate use when
+        translating.
+        Needs to contain columns:
+        `translation_from_col`, `translation_to_col`, `translation_factors_col`.
+
+    translation_from_col:
+        The name of the column in `translation` containing the current index
+        values of `vector`.
+
+    translation_to_col:
+        The name of the column in `translation` containing the desired output
+        index values. This will define the output index format.
+
+    translation_factors_col:
+        The name of the column in `translation` containing the translation
+        weights between `translation_from_col` and `translation_to_col`.
+        Where zone pairs do not exist, they will be infilled with
+        `translate_infill`.
+
+    from_unique_index:
+        A list of all the unique IDs in the input indexing system.
+
+    to_unique_index:
+        A list of all the unique IDs in the output indexing system.
+
+    translation_dtype:
+        The numpy datatype to use to do the translation. If None, then the
+        dtype of `vector` is used. Where such high precision
+        isn't needed, a more memory and time efficient data type can be used.
+
+    vector_infill:
+        The value to use to infill any missing vector values.
+
+    translate_infill:
+        The value to use to infill any missing translation factors.
+
+    check_totals:
+        Whether to check that the input and output matrices sum to the same
+        total.
+
+    Returns
+    -------
+    translated_vector:
+        vector, translated into to_zone system.
+
+    See Also
+    --------
+    .numpy_vector_zone_translation()
+    """
+    # Check the matrix and translation dtypes match
+    if vector.index.dtype != translation[translation_from_col].dtype:
+        raise ValueError(
+            f"The datatype of the vector index must be the same as the "
+            f"translation datatype in from_zone_col for the zone "
+            f"translation to work.\n"
+            f"vector index data type: {vector.index.dtype}\n"
+            f"translation[from_zone_col] data type: {translation[translation_from_col].dtype}"
+        )
+
+    validators.unique_list(from_unique_index, name="from_unique_index")
+    validators.unique_list(to_unique_index, name="to_unique_index")
+
+    # Make sure the vector only has the zones defined in from_unique_zones
+    missing_rows = set(vector.index.to_list()) - set(from_unique_index)
+    if len(missing_rows) > 0:
+        warnings.warn(
+            f"Some zones in vector.index have not been defined in "
+            f"from_unique_zones. These zones will be dropped before "
+            f"translating.\n"
+            f"Additional rows count: {len(missing_rows)}"
+        )
+
+    # Check all needed values are in from_zone_col zone col
+    trans_from_zones = set(translation[translation_from_col].unique())
+    missing_zones = set(from_unique_index) - trans_from_zones
+    if len(missing_zones) != 0:
+        warnings.warn(
+            f"Some zones in vector.index are missing in the translation. "
+            f"Infilling missing zones with translation infill.\n"
+            f"Missing zones count: {len(missing_zones)}"
+        )
+
+    # ## PREP AND TRANSLATE ## #
+    # Square the translation
+    translation = pd_utils.long_to_wide_infill(
+        df=translation,
+        index_col=translation_from_col,
+        columns_col=translation_to_col,
+        values_col=translation_factors_col,
+        index_vals=from_unique_index,
+        column_vals=to_unique_index,
+        infill=translate_infill,
+    )
+
+    # Sort vector and infill 0s
+    vector = vector.reindex(
+        index=from_unique_index,
+        fill_value=vector_infill,
+    )
+
+    # Translate and return
+    translated = numpy_vector_zone_translation(
+        vector=vector.values,
+        translation=translation.values,
+        translation_dtype=translation_dtype,
+        check_totals=check_totals,
+    )
+    return pd.Series(
+        data=translated,
+        index=to_unique_index,
+        name=vector.name,
+    )
+
+
+# TODO(BT): Bring over from normits_demand (once we have zoning systems):
+#  translate_vector_zoning
+#  translate_matrix_zoning
+#  get_long_translation
+#  get_long_pop_emp_translations

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -209,7 +209,7 @@ def numpy_matrix_zone_translation(
     col_translation: np.ndarray = None,
     translation_dtype: np.dtype = None,
     check_shapes: bool = True,
-    check_totals: bool = False,
+    check_totals: bool = True,
     slow_fallback: bool = True,
     chunk_size: int = 100,
 ) -> np.ndarray:
@@ -297,7 +297,7 @@ def numpy_matrix_zone_translation(
 
     # ## CONVERT DTYPES ## #
     if translation_dtype is None:
-        translation_dtype = matrix.dtype
+        translation_dtype = np.find_common_type([matrix.dtype, translation.dtype], [])
     matrix = _convert_dtypes(
         arr=matrix,
         to_type=translation_dtype,
@@ -379,7 +379,7 @@ def numpy_vector_zone_translation(
     translation: np.ndarray,
     translation_dtype: np.dtype = None,
     check_shapes: bool = True,
-    check_totals: bool = False,
+    check_totals: bool = True,
 ) -> np.ndarray:
     """Efficiently translates a vector between index systems
 
@@ -508,7 +508,7 @@ def pandas_matrix_zone_translation(
     translation_dtype: np.dtype = None,
     matrix_infill: float = 0.0,
     translate_infill: float = 0.0,
-    check_totals: bool = False,
+    check_totals: bool = True,
     slow_fallback: bool = True,
     chunk_size: int = 100,
 ) -> pd.DataFrame:
@@ -700,7 +700,7 @@ def pandas_vector_zone_translation(
     translation_dtype: np.dtype = None,
     vector_infill: float = 0.0,
     translate_infill: float = 0.0,
-    check_totals: bool = False,
+    check_totals: bool = True,
 ) -> pd.Series:
     # pylint: disable=too-many-arguments
     """Efficiently translates a pandas vector between index systems

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -84,7 +84,7 @@ def _lower_memory_matrix_zone_translation(
     kwargs = list()
     n_splits = matrix.shape[1] / chunk_size
     n_splits = 1 if n_splits <= 0 else n_splits
-    for vector_chunk in np.array_split(matrix, n_splits, axis=1):   # type: ignore
+    for vector_chunk in np.array_split(matrix, n_splits, axis=1):  # type: ignore
         kwargs.append(
             {
                 "vector_chunk": vector_chunk,
@@ -105,7 +105,7 @@ def _lower_memory_matrix_zone_translation(
     kwargs = list()
     n_splits = row_translated.shape[0] / chunk_size
     n_splits = 1 if n_splits <= 0 else n_splits
-    for vector_chunk in np.array_split(row_translated, n_splits, axis=0):   # type: ignore
+    for vector_chunk in np.array_split(row_translated, n_splits, axis=0):  # type: ignore
         kwargs.append(
             {
                 "vector_chunk": vector_chunk,

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -150,8 +150,7 @@ def _check_matrix_translation_shapes(
     n_zones_in, _ = row_translation.shape
     if n_zones_in != mat_rows:
         raise ValueError(
-            f"The given translation does not have the correct number of "
-            f"rows. Translation rows needs to match matrix rows for the "
+            f"Translation rows needs to match matrix rows for the "
             f"numpy zone translations to work.\n"
             f"Given matrix shape: {matrix.shape}\n"
             f"Given translation shape: {row_translation.shape}"
@@ -297,7 +296,8 @@ def numpy_matrix_zone_translation(
 
     # ## CONVERT DTYPES ## #
     if translation_dtype is None:
-        translation_dtype = np.find_common_type([matrix.dtype, translation.dtype], [])
+        dtypes = [matrix.dtype, row_translation.dtype, col_translation.dtype]
+        translation_dtype = np.find_common_type(dtypes, [])
     matrix = _convert_dtypes(
         arr=matrix,
         to_type=translation_dtype,

--- a/src/caf/toolkit/validators.py
+++ b/src/caf/toolkit/validators.py
@@ -25,7 +25,7 @@ LOG = logging.getLogger(__name__)
 # # # FUNCTIONS # # #
 # TODO(BT): Can this take a Collection instead?
 def unique_list(unique_vals: list[Any], name: str = "unique_zones") -> None:
-    """Validate that a list of unique values is unique
+    """Validate that a list of unique values is unique.
 
     Parameters
     ----------

--- a/src/caf/toolkit/validators.py
+++ b/src/caf/toolkit/validators.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
+"""Tools to validate items. These function return either True or False.
+
+These are mostly commonly used validations across the codebase.
 """
 # Built-Ins
 import logging
@@ -43,4 +45,7 @@ def unique_list(unique_vals: list[Any], name: str = "unique_zones") -> None:
         If `unique_vals` is not a unique list
     """
     if not toolbox.is_unique_list(unique_vals):
-        raise ValueError(f"Duplicate values found in {name}, making it invalid.")
+        raise ValueError(
+            f"Duplicate values found in {name}, making it invalid."
+            f"\n{unique_vals}\n{type(unique_vals[0])}"
+        )

--- a/src/caf/toolkit/validators.py
+++ b/src/caf/toolkit/validators.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+"""
+"""
+# Built-Ins
+import logging
+
+from typing import Any
+
+# Third Party
+
+# Local Imports
+# pylint: disable=import-error,wrong-import-position
+from caf.toolkit import toolbox
+
+# pylint: enable=import-error,wrong-import-position
+
+# # # CONSTANTS # # #
+LOG = logging.getLogger(__name__)
+
+# # # CLASSES # # #
+
+
+# # # FUNCTIONS # # #
+# TODO(BT): Can this take a Collection instead?
+def unique_list(unique_vals: list[Any], name: str = "unique_zones") -> None:
+    """Validate that a list of unique values is unique
+
+    Parameters
+    ----------
+    unique_vals:
+        The list of unique values to validate.
+
+    name:
+        The name to give to `unique_vals` if an error is raised.
+
+    Returns
+    -------
+    None
+
+    Raises
+    ------
+    ValueError:
+        If `unique_vals` is not a unique list
+    """
+    if not toolbox.is_unique_list(unique_vals):
+        raise ValueError(f"Duplicate values found in {name}, making it invalid.")

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""Tests for the caf.toolkit.translation module"""
+# Built-Ins
+import dataclasses
+
+from typing import Any
+from typing import Optional
+
+# Third Party
+import pytest
+import numpy as np
+
+
+# Local Imports
+# pylint: disable=import-error,wrong-import-position
+from caf.toolkit import translation
+
+# pylint: enable=import-error,wrong-import-position
+
+# # # CONSTANTS # # #
+
+
+# # # CLASSES # # #
+@dataclasses.dataclass
+class NumpyVectorResults:
+    """Collection of I/O data for a numpy vector translation"""
+
+    vector: np.ndarray
+    translation: np.ndarray
+    expected_result: np.ndarray
+    translation_dtype: Optional[np.dtype] = None
+
+    def input_kwargs(self, check_shapes: bool, check_totals: bool) -> dict[str, Any]:
+        """Return a dictionary of key-word arguments"""
+        return {
+            "vector": self.vector,
+            "translation": self.translation,
+            "translation_dtype": self.translation_dtype,
+            "check_shapes": check_shapes,
+            "check_totals": check_totals,
+        }
+
+
+# # # FIXTURES # # #
+# TODO(BT): Pandas vector will build on this
+@pytest.fixture(name="numpy_vector_aggregation", scope="class")
+def fixture_numpy_vector_aggregation() -> NumpyVectorResults:
+    """Generate an aggregation vector, translation, and results"""
+    trans = np.array(
+        [
+            [1, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [0, 0, 1],
+        ]
+    )
+
+    vector = np.array([8, 2, 8, 8, 5])
+
+    expected_result = np.array([10, 8, 13])
+
+    return NumpyVectorResults(
+        vector=vector,
+        translation=trans,
+        expected_result=expected_result,
+    )
+
+
+@pytest.fixture(name="numpy_vector_split", scope="class")
+def fixture_numpy_vector_split() -> NumpyVectorResults:
+    """Generate a splitting vector, translation, and results"""
+    trans = np.array(
+        [
+            [0.5, 0.0, 0.5],
+            [0.25, 0.5, 0.25],
+            [0, 1, 0],
+            [0.5, 0.0, 0.5],
+            [0.25, 0.5, 0.25],
+        ]
+    )
+
+    vector = np.array([8, 2, 8, 8, 5])
+
+    expected_result = np.array([9.75, 11.5, 9.75])
+
+    return NumpyVectorResults(
+        vector=vector,
+        translation=trans,
+        expected_result=expected_result,
+    )
+
+
+# # # TESTS # # #
+@pytest.mark.usefixtures(
+    "numpy_vector_aggregation",
+    "numpy_vector_split",
+)
+class TestNumpyVector:
+    """Tests for caf.toolkit.translation.numpy_vector_zone_translation"""
+
+    # TODO(BT): Check totals, and check translation dtype works
+    # TODO(BT): Use this class as framework for all other tests
+
+    @pytest.mark.parametrize("check_shapes", [True, False])
+    def test_non_vector(self, numpy_vector_split: NumpyVectorResults, check_shapes: bool):
+        """Test for error when non-vector given"""
+        # Convert vector to matrix
+        new_vector = numpy_vector_split.vector
+        new_vector = np.broadcast_to(new_vector, (new_vector.shape[0], new_vector.shape[0]))
+
+        # Set expected error message
+        if check_shapes:
+            msg = "not a vector"
+        else:
+            msg = "was there a shape mismatch?"
+
+        # Call with expected error
+        kwargs = numpy_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
+        with pytest.raises(ValueError, match=msg):
+            translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
+
+    @pytest.mark.parametrize("check_shapes", [True, False])
+    def test_translation_shape(
+        self, numpy_vector_split: NumpyVectorResults, check_shapes: bool
+    ):
+        """Test for error when wrong shape translation"""
+        # Convert vector to matrix
+        new_trans = numpy_vector_split.translation
+        new_trans = np.vstack([new_trans, new_trans])
+
+        # Set expected error message
+        if check_shapes:
+            msg = "translation does not have the correct number of rows"
+        else:
+            msg = "was there a shape mismatch?"
+
+        # Call with expected error
+        kwargs = numpy_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
+        with pytest.raises(ValueError, match=msg):
+            translation.numpy_vector_zone_translation(**kwargs | {"translation": new_trans})
+
+    @pytest.mark.parametrize(
+        "numpy_vector_str",
+        ["numpy_vector_aggregation", "numpy_vector_split"],
+    )
+    def test_vector_like(self, numpy_vector_str: NumpyVectorResults, request):
+        """Test vector-like arrays (empty in 2nd dim)"""
+        numpy_vector = request.getfixturevalue(numpy_vector_str)
+        new_vector = np.expand_dims(numpy_vector.vector, 1)
+        kwargs = numpy_vector.input_kwargs(check_shapes=True, check_totals=True)
+        result = translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
+        np.testing.assert_allclose(result, numpy_vector.expected_result)
+
+    @pytest.mark.parametrize(
+        "numpy_vector_str",
+        ["numpy_vector_aggregation", "numpy_vector_split"],
+    )
+    def test_translation_correct(self, numpy_vector_str: NumpyVectorResults, request):
+        """Test that aggregation and splitting"""
+        numpy_vector = request.getfixturevalue(numpy_vector_str)
+        kwargs = numpy_vector.input_kwargs(check_shapes=True, check_totals=True)
+        result = translation.numpy_vector_zone_translation(**kwargs)
+        np.testing.assert_allclose(result, numpy_vector.expected_result)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -65,6 +65,7 @@ class NumpyMatrixResults:
         self,
         check_shapes: bool = True,
         check_totals: bool = True,
+        force_slow: bool = False,
     ) -> dict[str, Any]:
         """Return a dictionary of key-word arguments"""
         return {
@@ -74,6 +75,7 @@ class NumpyMatrixResults:
             "translation_dtype": self.translation_dtype,
             "check_shapes": check_shapes,
             "check_totals": check_totals,
+            "_force_slow": force_slow,
         }
 
 
@@ -799,10 +801,12 @@ class TestNumpyMatrix:
         ],
     )
     @pytest.mark.parametrize("check_totals", [True, False])
+    @pytest.mark.parametrize("force_slow", [True, False])
     def test_translation_correct(
         self,
         np_matrix_str: str,
         check_totals: bool,
+        force_slow: bool,
         request,
     ):
         """Test translation works as expected
@@ -812,6 +816,6 @@ class TestNumpyMatrix:
         """
         np_mat = request.getfixturevalue(np_matrix_str)
         result = translation.numpy_matrix_zone_translation(
-            **np_mat.input_kwargs(check_totals=check_totals)
+            **np_mat.input_kwargs(check_totals=check_totals, force_slow=force_slow)
         )
         np.testing.assert_allclose(result, np_mat.expected_result)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -6,6 +6,8 @@ import dataclasses
 from typing import Any
 from typing import Optional
 
+import pandas as pd
+
 # Third Party
 import pytest
 import numpy as np
@@ -39,6 +41,93 @@ class NumpyVectorResults:
             "check_shapes": check_shapes,
             "check_totals": check_totals,
         }
+
+
+@dataclasses.dataclass
+class PandasTranslation:
+    """Container for a pandas based translation
+
+    Takes a numpy translation and converts to a standard pandas format
+    """
+
+    np_translation: dataclasses.InitVar[np.ndarray]
+    translation_from_col: str = "from_zone_id"
+    translation_to_col: str = "to_zone_id"
+    translation_factors_col: str = "factors"
+    translation: pd.DataFrame = dataclasses.field(init=False)
+    unique_from: list[Any] = dataclasses.field(init=False)
+    unique_to: list[Any] = dataclasses.field(init=False)
+
+    def __post_init__(self, np_translation: np.ndarray):
+        """Convert numpy translation to pandas"""
+        # Convert translation from numpy to long pandas
+        df = pd.DataFrame(data=np_translation)
+        df.index.name = self.translation_from_col
+        df.columns.name = self.translation_to_col
+        df.columns += 1
+        df.index += 1
+        df = df.reset_index()
+        self.translation = df.melt(
+            id_vars=self.translation_from_col,
+            value_name=self.translation_factors_col,
+        )
+
+        # Get the unique from / to lists
+        self.unique_from = self.translation[self.translation_from_col].unique().tolist()
+        self.unique_to = self.translation[self.translation_to_col].unique().tolist()
+
+    def to_kwargs(self) -> dict[str, Any]:
+        """Return a dictionary of key-word arguments"""
+        return {
+            "translation": self.translation,
+            "translation_from_col": self.translation_from_col,
+            "translation_to_col": self.translation_to_col,
+            "translation_factors_col": self.translation_factors_col,
+        }
+
+
+@dataclasses.dataclass
+class PandasVectorResults:
+    """Collection of I/O data for a pandas vector translation"""
+
+    np_vector: dataclasses.InitVar[np.ndarray]
+    np_expected_result: dataclasses.InitVar[np.ndarray]
+    translation: PandasTranslation
+    translation_dtype: Optional[np.dtype] = None
+
+    vector: pd.Series = dataclasses.field(init=False)
+    expected_result: pd.Series = dataclasses.field(init=False)
+    from_unique_index: list[Any] = dataclasses.field(init=False)
+    to_unique_index: list[Any] = dataclasses.field(init=False)
+
+    def __post_init__(self, np_vector: np.ndarray, np_expected_result: np.ndarray):
+        """Convert numpy objects to pandas"""
+        # Input and results
+        self.vector = pd.Series(data=np_vector)
+        self.vector.index += 1
+        self.expected_result = pd.Series(data=np_expected_result)
+        self.expected_result.index += 1
+
+        # Base from / to zones on translation
+        self.from_unique_index = self.translation.unique_from
+        self.to_unique_index = self.translation.unique_to
+
+    def input_kwargs(
+        self,
+        check_totals: bool,
+        vector_infill: float,
+        translate_infill: float,
+    ) -> dict[str, Any]:
+        """Return a dictionary of key-word arguments"""
+        return {
+            "vector": self.vector,
+            "from_unique_index": self.from_unique_index,
+            "to_unique_index": self.to_unique_index,
+            "translation_dtype": self.translation_dtype,
+            "vector_infill": vector_infill,
+            "translate_infill": translate_infill,
+            "check_totals": check_totals,
+        } | self.translation.to_kwargs()
 
 
 # # # FIXTURES # # #
@@ -82,6 +171,30 @@ def fixture_simple_np_float_translation() -> np.ndarray:
             [0.25, 0.5, 0.25],
         ]
     )
+
+
+@pytest.fixture(name="simple_pd_int_translation", scope="class")
+def fixture_simple_pd_int_translation(
+    simple_np_int_translation: np.ndarray,
+) -> PandasTranslation:
+    """Generate a simple 5 to 3 complete translation array"""
+    return PandasTranslation(simple_np_int_translation)
+
+
+@pytest.fixture(name="incomplete_pd_int_translation", scope="class")
+def fixture_incomplete_pd_int_translation(
+    incomplete_np_int_translation: np.ndarray,
+) -> PandasTranslation:
+    """Generate a simple 5 to 3 complete translation array"""
+    return PandasTranslation(incomplete_np_int_translation)
+
+
+@pytest.fixture(name="simple_pd_float_translation", scope="class")
+def fixture_simple_pd_float_translation(
+    simple_np_float_translation: np.ndarray,
+) -> PandasTranslation:
+    """Generate a simple 5 to 3 complete translation array"""
+    return PandasTranslation(simple_np_float_translation)
 
 
 # TODO(BT): Pandas vector will build on this
@@ -132,6 +245,32 @@ def fixture_np_translation_dtype(simple_np_int_translation: np.ndarray) -> Numpy
     )
 
 
+@pytest.fixture(name="pd_vector_aggregation", scope="class")
+def fixture_pd_vector_aggregation(
+    np_vector_aggregation: NumpyVectorResults,
+    simple_pd_int_translation: PandasTranslation,
+) -> PandasVectorResults:
+    """Generate an aggregation vector, translation, and results"""
+    return PandasVectorResults(
+        np_vector=np_vector_aggregation.vector,
+        np_expected_result=np_vector_aggregation.expected_result,
+        translation=simple_pd_int_translation,
+    )
+
+
+@pytest.fixture(name="pd_vector_split", scope="class")
+def fixture_pd_vector_split(
+    np_vector_split: NumpyVectorResults,
+    simple_pd_float_translation: PandasTranslation,
+) -> PandasVectorResults:
+    """Generate a splitting vector, translation, and results"""
+    return PandasVectorResults(
+        np_vector=np_vector_split.vector,
+        np_expected_result=np_vector_split.expected_result,
+        translation=simple_pd_float_translation,
+    )
+
+
 # # # TESTS # # #
 @pytest.mark.usefixtures(
     "np_vector_aggregation",
@@ -141,8 +280,6 @@ def fixture_np_translation_dtype(simple_np_int_translation: np.ndarray) -> Numpy
 )
 class TestNumpyVector:
     """Tests for caf.toolkit.translation.numpy_vector_zone_translation"""
-
-    # TODO(BT): Use this class as framework for all other tests
 
     @pytest.mark.parametrize("check_totals", [True, False])
     def test_dropped_totals(self, np_incomplete: NumpyVectorResults, check_totals: bool):
@@ -171,11 +308,13 @@ class TestNumpyVector:
         # Call with expected error
         kwargs = np_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
         with pytest.raises(ValueError, match=msg):
-            translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
+            translation.numpy_vector_zone_translation(**(kwargs | {"vector": new_vector}))
 
     @pytest.mark.parametrize("check_shapes", [True, False])
     def test_translation_shape(
-        self, np_vector_split: NumpyVectorResults, check_shapes: bool,
+        self,
+        np_vector_split: NumpyVectorResults,
+        check_shapes: bool,
     ):
         """Test for error when wrong shape translation"""
         # Convert vector to matrix
@@ -191,18 +330,18 @@ class TestNumpyVector:
         # Call with expected error
         kwargs = np_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
         with pytest.raises(ValueError, match=msg):
-            translation.numpy_vector_zone_translation(**kwargs | {"translation": new_trans})
+            translation.numpy_vector_zone_translation(**(kwargs | {"translation": new_trans}))
 
     @pytest.mark.parametrize(
         "np_vector_str",
         ["np_vector_aggregation", "np_vector_split"],
     )
-    def test_vector_like(self, np_vector_str: NumpyVectorResults, request):
+    def test_vector_like(self, np_vector_str: str, request):
         """Test vector-like arrays (empty in 2nd dim)"""
         np_vector = request.getfixturevalue(np_vector_str)
         new_vector = np.expand_dims(np_vector.vector, 1)
         kwargs = np_vector.input_kwargs(check_shapes=True, check_totals=True)
-        result = translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
+        result = translation.numpy_vector_zone_translation(**(kwargs | {"vector": new_vector}))
         np.testing.assert_allclose(result, np_vector.expected_result)
 
     @pytest.mark.parametrize(
@@ -210,7 +349,12 @@ class TestNumpyVector:
         ["np_vector_aggregation", "np_vector_split"],
     )
     @pytest.mark.parametrize("check_totals", [True, False])
-    def test_translation_correct(self, np_vector_str: NumpyVectorResults, check_totals: bool, request,):
+    def test_translation_correct(
+        self,
+        np_vector_str: str,
+        check_totals: bool,
+        request,
+    ):
         """Test that aggregation and splitting give correct results
 
         Also checks that totals are correctly checked.
@@ -219,3 +363,47 @@ class TestNumpyVector:
         kwargs = np_vector.input_kwargs(check_shapes=True, check_totals=check_totals)
         result = translation.numpy_vector_zone_translation(**kwargs)
         np.testing.assert_allclose(result, np_vector.expected_result)
+
+
+@pytest.mark.usefixtures(
+    "pd_vector_aggregation",
+    "pd_vector_split",
+)
+class TestPandasVector:
+    """Tests for caf.toolkit.translation.pandas_vector_zone_translation"""
+
+    @pytest.mark.parametrize(
+        "pd_vector_str",
+        ["pd_vector_aggregation", "pd_vector_split"],
+    )
+    def test_series_like(self, pd_vector_str: str, request):
+        """Test vector-like arrays (empty in 2nd dim)"""
+        pd_vector = request.getfixturevalue(pd_vector_str)
+        new_vector = pd.DataFrame(pd_vector.vector)
+        kwargs = pd_vector.input_kwargs(check_totals=True, vector_infill=0, translate_infill=0)
+        result = translation.pandas_vector_zone_translation(
+            **(kwargs | {"vector": new_vector})
+        )
+        pd.testing.assert_series_equal(result, pd_vector.expected_result, check_names=False)
+
+    @pytest.mark.parametrize(
+        "pd_vector_str",
+        ["pd_vector_aggregation", "pd_vector_split"],
+    )
+    @pytest.mark.parametrize("check_totals", [True, False])
+    def test_translation_correct(
+        self,
+        pd_vector_str: str,
+        check_totals: bool,
+        request,
+    ):
+        """Test that aggregation and splitting give correct results
+
+        Also checks that totals are correctly checked.
+        """
+        pd_vector = request.getfixturevalue(pd_vector_str)
+        kwargs = pd_vector.input_kwargs(
+            check_totals=check_totals, vector_infill=0, translate_infill=0
+        )
+        result = translation.pandas_vector_zone_translation(**kwargs)
+        pd.testing.assert_series_equal(result, pd_vector.expected_result)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -42,71 +42,124 @@ class NumpyVectorResults:
 
 
 # # # FIXTURES # # #
+@pytest.fixture(name="simple_np_int_translation", scope="class")
+def fixture_simple_np_int_translation() -> np.ndarray:
+    """Generate a simple 5 to 3 complete translation array"""
+    return np.array(
+        [
+            [1, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [0, 0, 1],
+        ]
+    )
+
+
+@pytest.fixture(name="incomplete_np_int_translation", scope="class")
+def fixture_incomplete_np_int_translation() -> np.ndarray:
+    """Generate a simple 5 to 3 complete translation array"""
+    return np.array(
+        [
+            [1, 0, 0],
+            [1, 0, 0],
+            [0, 1, 0],
+            [0, 0, 1],
+            [0, 0, 0.6],
+        ]
+    )
+
+
+@pytest.fixture(name="simple_np_float_translation", scope="class")
+def fixture_simple_np_float_translation() -> np.ndarray:
+    """Generate a simple 5 to 3 complete translation array"""
+    return np.array(
+        [
+            [0.5, 0.0, 0.5],
+            [0.25, 0.5, 0.25],
+            [0, 1, 0],
+            [0.5, 0.0, 0.5],
+            [0.25, 0.5, 0.25],
+        ]
+    )
+
+
 # TODO(BT): Pandas vector will build on this
-@pytest.fixture(name="numpy_vector_aggregation", scope="class")
-def fixture_numpy_vector_aggregation() -> NumpyVectorResults:
+@pytest.fixture(name="np_vector_aggregation", scope="class")
+def fixture_np_vector_aggregation(simple_np_int_translation: np.ndarray) -> NumpyVectorResults:
     """Generate an aggregation vector, translation, and results"""
-    trans = np.array(
-        [
-            [1, 0, 0],
-            [1, 0, 0],
-            [0, 1, 0],
-            [0, 0, 1],
-            [0, 0, 1],
-        ]
-    )
-
-    vector = np.array([8, 2, 8, 8, 5])
-
-    expected_result = np.array([10, 8, 13])
-
     return NumpyVectorResults(
-        vector=vector,
-        translation=trans,
-        expected_result=expected_result,
+        vector=np.array([8, 2, 8, 8, 5]),
+        translation=simple_np_int_translation,
+        expected_result=np.array([10, 8, 13]),
     )
 
 
-@pytest.fixture(name="numpy_vector_split", scope="class")
-def fixture_numpy_vector_split() -> NumpyVectorResults:
+@pytest.fixture(name="np_vector_split", scope="class")
+def fixture_np_vector_split(simple_np_float_translation: np.ndarray) -> NumpyVectorResults:
     """Generate a splitting vector, translation, and results"""
-    trans = np.array(
-        [
-            [0.5, 0.0, 0.5],
-            [0.25, 0.5, 0.25],
-            [0, 1, 0],
-            [0.5, 0.0, 0.5],
-            [0.25, 0.5, 0.25],
-        ]
+    return NumpyVectorResults(
+        vector=np.array([8, 2, 8, 8, 5]),
+        translation=simple_np_float_translation,
+        expected_result=np.array([9.75, 11.5, 9.75]),
     )
 
-    vector = np.array([8, 2, 8, 8, 5])
 
-    expected_result = np.array([9.75, 11.5, 9.75])
+@pytest.fixture(name="np_incomplete", scope="class")
+def fixture_np_incomplete(incomplete_np_int_translation: np.ndarray) -> NumpyVectorResults:
+    """Generate an incomplete vector, translation, and results
 
+    Incomplete meaning some demand will be dropped during the translation
+    """
     return NumpyVectorResults(
-        vector=vector,
-        translation=trans,
-        expected_result=expected_result,
+        vector=np.array([8, 2, 8, 8, 5]),
+        translation=incomplete_np_int_translation,
+        expected_result=np.array([10, 8, 11]),
+    )
+
+
+@pytest.fixture(name="np_translation_dtype", scope="class")
+def fixture_np_translation_dtype(simple_np_int_translation: np.ndarray) -> NumpyVectorResults:
+    """Generate an incomplete vector, translation, and results
+
+    Incomplete meaning some demand will be dropped during the translation
+    """
+    return NumpyVectorResults(
+        vector=np.array([8.1, 2.2, 8.3, 8.4, 5.5]),
+        translation=simple_np_int_translation,
+        translation_dtype=np.int32,
+        expected_result=np.array([10, 8, 11]),
     )
 
 
 # # # TESTS # # #
 @pytest.mark.usefixtures(
-    "numpy_vector_aggregation",
-    "numpy_vector_split",
+    "np_vector_aggregation",
+    "np_vector_split",
+    "np_incomplete",
+    "np_translation_dtype",
 )
 class TestNumpyVector:
     """Tests for caf.toolkit.translation.numpy_vector_zone_translation"""
 
-    # TODO(BT): Check totals, and check translation dtype works
     # TODO(BT): Use this class as framework for all other tests
 
+    @pytest.mark.parametrize("check_totals", [True, False])
+    def test_dropped_totals(self, np_incomplete: NumpyVectorResults, check_totals: bool):
+        """Test for total checking with dropped demand"""
+        kwargs = np_incomplete.input_kwargs(check_shapes=True, check_totals=check_totals)
+        if not check_totals:
+            result = translation.numpy_vector_zone_translation(**kwargs)
+            np.testing.assert_allclose(result, np_incomplete.expected_result)
+        else:
+            with pytest.raises(ValueError, match="Some values seem to have been dropped"):
+                translation.numpy_vector_zone_translation(**kwargs)
+
     @pytest.mark.parametrize("check_shapes", [True, False])
-    def test_non_vector(self, numpy_vector_split: NumpyVectorResults, check_shapes: bool):
+    def test_non_vector(self, np_vector_split: NumpyVectorResults, check_shapes: bool):
         """Test for error when non-vector given"""
         # Convert vector to matrix
-        new_vector = numpy_vector_split.vector
+        new_vector = np_vector_split.vector
         new_vector = np.broadcast_to(new_vector, (new_vector.shape[0], new_vector.shape[0]))
 
         # Set expected error message
@@ -116,17 +169,17 @@ class TestNumpyVector:
             msg = "was there a shape mismatch?"
 
         # Call with expected error
-        kwargs = numpy_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
+        kwargs = np_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
         with pytest.raises(ValueError, match=msg):
             translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
 
     @pytest.mark.parametrize("check_shapes", [True, False])
     def test_translation_shape(
-        self, numpy_vector_split: NumpyVectorResults, check_shapes: bool
+        self, np_vector_split: NumpyVectorResults, check_shapes: bool,
     ):
         """Test for error when wrong shape translation"""
         # Convert vector to matrix
-        new_trans = numpy_vector_split.translation
+        new_trans = np_vector_split.translation
         new_trans = np.vstack([new_trans, new_trans])
 
         # Set expected error message
@@ -136,29 +189,33 @@ class TestNumpyVector:
             msg = "was there a shape mismatch?"
 
         # Call with expected error
-        kwargs = numpy_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
+        kwargs = np_vector_split.input_kwargs(check_shapes=check_shapes, check_totals=True)
         with pytest.raises(ValueError, match=msg):
             translation.numpy_vector_zone_translation(**kwargs | {"translation": new_trans})
 
     @pytest.mark.parametrize(
-        "numpy_vector_str",
-        ["numpy_vector_aggregation", "numpy_vector_split"],
+        "np_vector_str",
+        ["np_vector_aggregation", "np_vector_split"],
     )
-    def test_vector_like(self, numpy_vector_str: NumpyVectorResults, request):
+    def test_vector_like(self, np_vector_str: NumpyVectorResults, request):
         """Test vector-like arrays (empty in 2nd dim)"""
-        numpy_vector = request.getfixturevalue(numpy_vector_str)
-        new_vector = np.expand_dims(numpy_vector.vector, 1)
-        kwargs = numpy_vector.input_kwargs(check_shapes=True, check_totals=True)
+        np_vector = request.getfixturevalue(np_vector_str)
+        new_vector = np.expand_dims(np_vector.vector, 1)
+        kwargs = np_vector.input_kwargs(check_shapes=True, check_totals=True)
         result = translation.numpy_vector_zone_translation(**kwargs | {"vector": new_vector})
-        np.testing.assert_allclose(result, numpy_vector.expected_result)
+        np.testing.assert_allclose(result, np_vector.expected_result)
 
     @pytest.mark.parametrize(
-        "numpy_vector_str",
-        ["numpy_vector_aggregation", "numpy_vector_split"],
+        "np_vector_str",
+        ["np_vector_aggregation", "np_vector_split"],
     )
-    def test_translation_correct(self, numpy_vector_str: NumpyVectorResults, request):
-        """Test that aggregation and splitting"""
-        numpy_vector = request.getfixturevalue(numpy_vector_str)
-        kwargs = numpy_vector.input_kwargs(check_shapes=True, check_totals=True)
+    @pytest.mark.parametrize("check_totals", [True, False])
+    def test_translation_correct(self, np_vector_str: NumpyVectorResults, check_totals: bool, request,):
+        """Test that aggregation and splitting give correct results
+
+        Also checks that totals are correctly checked.
+        """
+        np_vector = request.getfixturevalue(np_vector_str)
+        kwargs = np_vector.input_kwargs(check_shapes=True, check_totals=check_totals)
         result = translation.numpy_vector_zone_translation(**kwargs)
-        np.testing.assert_allclose(result, numpy_vector.expected_result)
+        np.testing.assert_allclose(result, np_vector.expected_result)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -363,18 +363,22 @@ def fixture_pd_incomplete(
 @pytest.fixture(name="np_matrix_aggregation", scope="class")
 def fixture_np_matrix_aggregation(simple_np_int_translation: np.ndarray) -> NumpyMatrixResults:
     """Generate a matrix, translation, and results"""
-    mat = np.array([
-        [4, 2, 3, 1, 1],
-        [2, 8, 3, 6, 6],
-        [5, 5, 6, 5, 9],
-        [4, 3, 3, 6, 8],
-        [8, 4, 8, 8, 1],
-    ])
-    expected_result = np.array([
-        [16,  6, 14],
-        [10,  6, 14],
-        [19, 11, 23],
-    ])
+    mat = np.array(
+        [
+            [4, 2, 3, 1, 1],
+            [2, 8, 3, 6, 6],
+            [5, 5, 6, 5, 9],
+            [4, 3, 3, 6, 8],
+            [8, 4, 8, 8, 1],
+        ]
+    )
+    expected_result = np.array(
+        [
+            [16, 6, 14],
+            [10, 6, 14],
+            [19, 11, 23],
+        ]
+    )
     return NumpyMatrixResults(
         mat=mat,
         translation=simple_np_int_translation,
@@ -383,13 +387,18 @@ def fixture_np_matrix_aggregation(simple_np_int_translation: np.ndarray) -> Nump
 
 
 @pytest.fixture(name="np_matrix_aggregation2", scope="class")
-def fixture_np_matrix_aggregation2(np_matrix_aggregation: NumpyMatrixResults, simple_np_int_translation2: np.ndarray,) -> NumpyMatrixResults:
+def fixture_np_matrix_aggregation2(
+    np_matrix_aggregation: NumpyMatrixResults,
+    simple_np_int_translation2: np.ndarray,
+) -> NumpyMatrixResults:
     """Generate a matrix, translation, and results"""
-    expected_result = np.array([
-        [14,  6, 16],
-        [14,  6, 10],
-        [23, 11, 19],
-    ])
+    expected_result = np.array(
+        [
+            [14, 6, 16],
+            [14, 6, 10],
+            [23, 11, 19],
+        ]
+    )
     return NumpyMatrixResults(
         mat=np_matrix_aggregation.mat,
         translation=np_matrix_aggregation.translation,
@@ -399,13 +408,18 @@ def fixture_np_matrix_aggregation2(np_matrix_aggregation: NumpyMatrixResults, si
 
 
 @pytest.fixture(name="np_matrix_split", scope="class")
-def fixture_np_matrix_split(np_matrix_aggregation: NumpyMatrixResults, simple_np_float_translation: np.ndarray,) -> NumpyMatrixResults:
+def fixture_np_matrix_split(
+    np_matrix_aggregation: NumpyMatrixResults,
+    simple_np_float_translation: np.ndarray,
+) -> NumpyMatrixResults:
     """Generate a matrix, translation, and results"""
-    expected_result = np.array([
-        [9.6875, 11.625,  9.6875],
-        [16.875, 23.25, 16.875],
-        [9.6875, 11.625,  9.6875],
-    ])
+    expected_result = np.array(
+        [
+            [9.6875, 11.625, 9.6875],
+            [16.875, 23.25, 16.875],
+            [9.6875, 11.625, 9.6875],
+        ]
+    )
     return NumpyMatrixResults(
         mat=np_matrix_aggregation.mat,
         translation=simple_np_float_translation,
@@ -419,18 +433,22 @@ def fixture_np_matrix_dtype(simple_np_int_translation: np.ndarray) -> NumpyMatri
 
     Incomplete meaning some demand will be dropped during the translation
     """
-    mat = np.array([
-        [4.2, 2.4, 3.6, 1.8, 1.1],
-        [2.2, 8.4, 3.6, 6.8, 6.1],
-        [5.2, 5.4, 6.6, 5.8, 9.1],
-        [4.2, 3.4, 3.6, 6.8, 8.1],
-        [8.2, 4.4, 8.6, 8.8, 1.1],
-    ])
-    expected_result = np.array([
-        [16,  6, 14],
-        [10,  6, 14],
-        [19, 11, 23],
-    ])
+    mat = np.array(
+        [
+            [4.2, 2.4, 3.6, 1.8, 1.1],
+            [2.2, 8.4, 3.6, 6.8, 6.1],
+            [5.2, 5.4, 6.6, 5.8, 9.1],
+            [4.2, 3.4, 3.6, 6.8, 8.1],
+            [8.2, 4.4, 8.6, 8.8, 1.1],
+        ]
+    )
+    expected_result = np.array(
+        [
+            [16, 6, 14],
+            [10, 6, 14],
+            [19, 11, 23],
+        ]
+    )
     return NumpyMatrixResults(
         mat=mat,
         translation=simple_np_int_translation,
@@ -440,16 +458,20 @@ def fixture_np_matrix_dtype(simple_np_int_translation: np.ndarray) -> NumpyMatri
 
 
 @pytest.fixture(name="np_matrix_incomplete", scope="class")
-def fixture_np_matrix_incomplete(incomplete_np_int_translation: np.ndarray, np_matrix_aggregation: NumpyMatrixResults) -> NumpyMatrixResults:
+def fixture_np_matrix_incomplete(
+    incomplete_np_int_translation: np.ndarray, np_matrix_aggregation: NumpyMatrixResults
+) -> NumpyMatrixResults:
     """Generate an incomplete vector, translation, and results
 
     Incomplete meaning some demand will be dropped during the translation
     """
-    expected_result = np.array([
-        [16,  6, 11.2],
-        [10,  6, 10.4],
-        [14.2, 7.8, 15.96],
-    ])
+    expected_result = np.array(
+        [
+            [16, 6, 11.2],
+            [10, 6, 10.4],
+            [14.2, 7.8, 15.96],
+        ]
+    )
     return NumpyMatrixResults(
         mat=np_matrix_aggregation.mat,
         translation=incomplete_np_int_translation,
@@ -714,6 +736,9 @@ class TestPandasVector:
 class TestNumpyMatrix:
     """Tests for caf.toolkit.translation.numpy_matrix_zone_translation"""
 
+    # TODO(BT): Test forcing slower method!
+    # Can't test running out of memory on GitHub - might write test though
+
     def test_mismatch_translations(self, np_matrix_aggregation2: NumpyMatrixResults):
         """Check an error is raised with a non-square matrix given"""
         col_trans = np_matrix_aggregation2.col_translation
@@ -731,7 +756,7 @@ class TestNumpyMatrix:
         col_trans = np_matrix_aggregation2.col_translation
         new_kwargs = {
             "translation": np.delete(new_trans, 0, axis=0),
-            "col_translation": np.delete(col_trans, 0, axis=0)
+            "col_translation": np.delete(col_trans, 0, axis=0),
         }
         msg = "Translation rows needs to match matrix rows"
 
@@ -752,7 +777,9 @@ class TestNumpyMatrix:
             )
 
     @pytest.mark.parametrize("check_totals", [True, False])
-    def test_dropped_totals(self, np_matrix_incomplete: NumpyMatrixResults, check_totals: bool):
+    def test_dropped_totals(
+        self, np_matrix_incomplete: NumpyMatrixResults, check_totals: bool
+    ):
         """Test for total checking with dropped demand"""
         kwargs = np_matrix_incomplete.input_kwargs(check_totals=check_totals)
         if not check_totals:
@@ -764,10 +791,20 @@ class TestNumpyMatrix:
 
     @pytest.mark.parametrize(
         "np_matrix_str",
-        ["np_matrix_aggregation", "np_matrix_aggregation2", "np_matrix_split", "np_matrix_dtype"],
+        [
+            "np_matrix_aggregation",
+            "np_matrix_aggregation2",
+            "np_matrix_split",
+            "np_matrix_dtype",
+        ],
     )
     @pytest.mark.parametrize("check_totals", [True, False])
-    def test_translation_correct(self, np_matrix_str: str, check_totals: bool, request,):
+    def test_translation_correct(
+        self,
+        np_matrix_str: str,
+        check_totals: bool,
+        request,
+    ):
         """Test translation works as expected
 
         Tests the matrix aggregation, using 2 different translations, and


### PR DESCRIPTION
Describe Changes
---
Added code to translate pandas/numpy based vectors and matrices between different indexing systems. Can use direct or weighted translations.
If the memory is available, the translations are very quick - but will fall back to a slower method if the memory isn't available

Task Checklist
----
- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Have integration tests been added (if applicable, to test modules of functionality)
- [x] Updated RELEASE.md to reflect changes in PR
- [x] Have new dependencies been added?
  - [x] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [x] Have they been added to `setup.cfg`
