### PR TITLE
Added `write_example` method to BaseConfig

### DIFF
--- a/src/caf/toolkit/config_base.py
+++ b/src/caf/toolkit/config_base.py
@@ -124,6 +124,31 @@ class BaseConfig(pydantic.BaseModel):
             file.write(self.to_yaml())
         # pylint: enable = unspecified-encoding
 
+    @classmethod
+    def write_example(cls, path: Path, **examples: str) -> None:
+        """Write examples to a config file.
+
+        Parameters
+        ----------
+        path : Path
+            Path to the YAML file to write.
+        examples : str
+            Fields of the config to write, any missing fields
+            are filled in with their default value (if they have
+            one) or 'REQUIRED' / 'OPTIONAL'.
+        """
+        data = {}
+        for name, field in cls.__fields__.items():
+            if field.default is not None:
+                value = field.default
+            else:
+                value = "REQUIRED" if field.required else "OPTIONAL"
+
+            data[name] = examples.get(name, value)
+
+        example = cls.construct(**data)
+        example.save_yaml(path)
+
 
 # # # FUNCTIONS # # #
 def _remove_none_dict(data: dict) -> dict:


### PR DESCRIPTION
Describe Changes
---

Updated `BaseConfig` class to have a method which will write an example config file. The method allows the user to provide examples for each of the fields but will fill in any missing with their default value (if available) or 'REQUIRED' / 'OPTIONAL'.

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [x] Have new dependencies been added? No
  - [ ] ~~Have they been added to either `requirements.txt` or `requirements_dev.txt`.~~
  - [ ] ~~Have they been added to `setup.cfg`~~
