### PR TITLE
Cap numpy version number #19

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Required libraries
-numpy>=1.19.0
+numpy>=1.19.0,<1.25.0
 pandas>=1.4.0
 tqdm>=4.50.2
 sparse>=0.13.0


### PR DESCRIPTION
Describe Changes
---
Added a cap to the numpy version, limiting it below version 1.25.0. Numba does not support this version of numpy

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `setup.cfg`
