### PR TITLE
Fix sparse_sum test failure

### DIFF
--- a/src/caf/toolkit/array_utils.py
+++ b/src/caf/toolkit/array_utils.py
@@ -152,7 +152,7 @@ def _sort_2d_sparse_coords_and_data(sparse_array: sparse.COO) -> sparse.COO:
     """Quickly sort the coordinates and data of a 2D sparse array.
 
     Used to replace the built-in sort method, as this is optimised for 2D
-    arrays abd will only work for them.
+    arrays and will only work for them.
 
     Parameters
     ----------

--- a/src/caf/toolkit/array_utils.py
+++ b/src/caf/toolkit/array_utils.py
@@ -466,7 +466,7 @@ def sparse_sum(
     sparse_array: sparse.COO,
     axis: Iterable[int] | int,
 ) -> sparse.COO:
-    ...
+    ...     # pragma: no cover
 
 
 @overload
@@ -474,7 +474,7 @@ def sparse_sum(
     sparse_array: sparse.COO,
     axis=None,
 ) -> float:
-    ...
+    ...     # pragma: no cover
 
 
 def sparse_sum(

--- a/src/caf/toolkit/array_utils.py
+++ b/src/caf/toolkit/array_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 # Built-Ins
 import logging
 
+from typing import overload
 from typing import Optional
 from typing import Iterable
 from typing import Sequence
@@ -149,6 +150,9 @@ def _sparse_unsorted_axis_swap(
 
 def _sort_2d_sparse_coords_and_data(sparse_array: sparse.COO) -> sparse.COO:
     """Quickly sort the coordinates and data of a 2D sparse array.
+
+    Used to replace the built-in sort method, as this is optimised for 2D
+    arrays abd will only work for them.
 
     Parameters
     ----------
@@ -457,9 +461,26 @@ def broadcast_sparse_matrix(
     )
 
 
+@overload
 def sparse_sum(
-    sparse_array: sparse.COO, axis: Optional[Iterable[int] | int] = None
+    sparse_array: sparse.COO,
+    axis: Iterable[int] | int,
 ) -> sparse.COO:
+    ...
+
+
+@overload
+def sparse_sum(
+    sparse_array: sparse.COO,
+    axis=None,
+) -> float:
+    ...
+
+
+def sparse_sum(
+    sparse_array: sparse.COO,
+    axis: Optional[Iterable[int] | int] = None,
+) -> sparse.COO | float:
     """Faster sum for a sparse.COO matrix.
 
     Converts the sum to a 2D operation and then optimises functionality for
@@ -497,6 +518,10 @@ def sparse_sum(
         sparse_array=sparse_array, new_axis_order=list(keep_axis) + axis
     )
 
+    # Return a float if summing all axis
+    if keep_axis == tuple():
+        return sparse_array.data.sum()
+
     # Reshape into the 2d array
     array = array.reshape(
         (
@@ -512,9 +537,7 @@ def sparse_sum(
     unique_idxs, _ = _get_unique_idxs_and_counts(array.coords[0])
     result = np.add.reduceat(array.data, unique_idxs)
 
-    if len(result) == 1:
-        return result[0]
-
+    # Reshape back to original final shape
     final_array = sparse.COO(
         data=result,
         coords=array.coords[:1, unique_idxs],
@@ -524,6 +547,4 @@ def sparse_sum(
         prune=True,
         fill_value=0,
     )
-
-    # Reshape back to original final shape
     return final_array.reshape(final_shape)

--- a/src/caf/toolkit/array_utils.py
+++ b/src/caf/toolkit/array_utils.py
@@ -466,7 +466,7 @@ def sparse_sum(
     sparse_array: sparse.COO,
     axis: Iterable[int] | int,
 ) -> sparse.COO:
-    ...     # pragma: no cover
+    ...  # pragma: no cover
 
 
 @overload
@@ -474,7 +474,7 @@ def sparse_sum(
     sparse_array: sparse.COO,
     axis=None,
 ) -> float:
-    ...     # pragma: no cover
+    ...  # pragma: no cover
 
 
 def sparse_sum(

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -77,6 +77,20 @@ class TestSparseSum:
         achieved = array_utils.sparse_sum(random_sparse_matrix)
         np.testing.assert_almost_equal(achieved, target)
 
+    @pytest.mark.parametrize("sum_axis", itertools.permutations((0, 1, 2), 3))
+    @pytest.mark.parametrize("repeat", range(2))
+    def test_sum_all_axis_explicit(
+        self,
+        random_3d_sparse_matrix: sparse.COO,
+        sum_axis: tuple[int, ...],
+        repeat: int,
+    ):
+        """Test that all axis can be summed together"""
+        del repeat
+        target = random_3d_sparse_matrix.sum()
+        achieved = array_utils.sparse_sum(random_3d_sparse_matrix, axis=sum_axis)
+        np.testing.assert_almost_equal(achieved, target)
+
     @pytest.mark.parametrize("sum_axis", axis_permutations(3))
     def test_sum_axis_subset(
         self, random_3d_sparse_matrix: sparse.COO, sum_axis: tuple[int, ...]
@@ -84,11 +98,11 @@ class TestSparseSum:
         """Test that all axis can be summed together"""
         target = random_3d_sparse_matrix.sum(axis=sum_axis)
         achieved = array_utils.sparse_sum(random_3d_sparse_matrix, axis=sum_axis)
-        # One of these sometimes returns a float instead of sparse. Leave separate
-        # until error comes back
         one = achieved.todense()
         two = target.todense()
         np.testing.assert_almost_equal(one, two)
+
+    # TODO(BT): Add test for sum all axis
 
     def test_sum_axis_int(self, random_3d_sparse_matrix: sparse.COO):
         """Test that all axis can be summed together"""

--- a/tests/test_array_utils.py
+++ b/tests/test_array_utils.py
@@ -98,11 +98,34 @@ class TestSparseSum:
         """Test that all axis can be summed together"""
         target = random_3d_sparse_matrix.sum(axis=sum_axis)
         achieved = array_utils.sparse_sum(random_3d_sparse_matrix, axis=sum_axis)
-        one = achieved.todense()
-        two = target.todense()
-        np.testing.assert_almost_equal(one, two)
+        np.testing.assert_almost_equal(achieved.todense(), target.todense())
 
-    # TODO(BT): Add test for sum all axis
+    def test_sum_axis_subset_1d_result(self):
+        """Test that all axis can be summed together
+
+        Specific test to cover error in #60
+        https://github.com/Transport-for-the-North/caf.toolkit/issues/60
+        """
+        # Setup specific values
+        shape = (13, 11, 7)
+        data = [0.16858948, 0.8229999, 0.02905589, 0.3573722]
+        coords = [
+            [3, 4, 7, 10],
+            [3, 4, 2, 6],
+            [4, 4, 4, 4],
+        ]
+        sum_axis = (1, 0)
+        arr = sparse.COO(
+            data=data,
+            shape=shape,
+            coords=coords,
+            fill_value=0,
+        )
+
+        # Run and assert
+        target = arr.todense().sum(axis=sum_axis)
+        achieved = array_utils.sparse_sum(arr, axis=sum_axis)
+        np.testing.assert_almost_equal(achieved.todense(), target)
 
     def test_sum_axis_int(self, random_3d_sparse_matrix: sparse.COO):
         """Test that all axis can be summed together"""


### PR DESCRIPTION
Describe Changes
---
Fixes an issue where if a sum over a sparse array returned an array containing a single value, this would be returned as a scalar value rather than a sparse array.

Fixes #60 

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `pyproject.toml`
