### PR TITLE
Fix to how self is imported

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,5 +22,7 @@ sphinx:
 # Optionally declare the Python requirements required to build your docs
 python:
    install:
+   - method: pip
+     path: .
    - requirements: docs/requirements.txt
    - requirements: requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,5 @@
 # Required libraries
 sphinx>=7.1.2
-caf.toolkit>=0.2.1
 sphinx-automodapi>=0.16.0
 pydata-sphinx-theme>=0.14.1
 graphviz>=0.20.1


### PR DESCRIPTION
caf.toolkit removed from requirements and instructions added to readthedocs.yml

Describe Changes
---

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `pyproject.toml`


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--97.org.readthedocs.build/en/97/

<!-- readthedocs-preview caftoolkit end -->