### PR TITLE
Tidied CLI error messages

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,3 +20,8 @@ there.
 Below, a brief summary of patches made since the previous version can be found.
 
 ### Next Release Notes
+
+- Added optional `TOOLKIT_TRACEBACK` env variable to enable tracebacks for CLI error
+  messages, by default only error text is output without the traceback
+- Added `arguments.getenv_bool` function which gets an env variable and converts to bool
+  with expected true (true, yes, y and 1) and false (false, no, n and 0) values

--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 # Built-Ins
 import argparse
 import logging
+import os
 import pathlib
 import re
 import warnings
@@ -39,6 +40,50 @@ _ARG_TYPE_LOOKUP: dict[str, type] = {
 
 class TypeAnnotationWarning(UserWarning):
     """Warning for issues parsing type annotations for CLI arguments."""
+
+
+def getenv_bool(name: str, default: bool) -> bool:
+    """Gets environment variable and converts to a boolean.
+
+    Normalizes the variable value by converting to lowercase
+    and stripping whitespace before bool conversion.
+
+    Parameters
+    ----------
+    name : str
+        Name of the environment variable.
+    default : bool
+        Default value for the environment variable.
+
+    Returns
+    -------
+    bool
+        True for: 'true', 'yes', 'y' or '1'.
+        False for: 'false', 'no', 'n' or '0'.
+
+    Raises
+    ------
+    ValueError
+        If the environment variable has an unexpected value.
+    """
+    value = os.getenv(name, default)
+    if isinstance(value, bool):
+        return value
+
+    true_str = ("true", "yes", "y", "1")
+    false_str = ("false", "no", "n", "0")
+
+    value = value.strip().lower()
+    if value in true_str:
+        return True
+    if value in false_str:
+        return False
+
+    raise ValueError(
+        f"unexpected value ({value!r}) for '{name}' env "
+        "variable should be one of the following:\n"
+        f" For true: {true_str}\n For false: {false_str}"
+    )
 
 
 def _parse_types(type_str: str) -> tuple[type, bool]:

--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -43,7 +43,7 @@ class TypeAnnotationWarning(UserWarning):
 
 
 def getenv_bool(name: str, default: bool) -> bool:
-    """Gets environment variable and converts to a boolean.
+    """Get environment variable and converts to a boolean.
 
     Normalizes the variable value by converting to lowercase
     and stripping whitespace before bool conversion.

--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -74,6 +74,8 @@ def getenv_bool(name: str, default: bool) -> bool:
     false_str = ("false", "no", "n", "0")
 
     value = value.strip().lower()
+    if value == "":
+        return default
     if value in true_str:
         return True
     if value in false_str:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -65,7 +65,7 @@ def fix_matrix_translate_config(
 class TestParseArgs:
     """Test `parse_args` function to make sure it returns the correct arguments."""
 
-    @pytest.mark.parametrize("type_", ["translate", "matrix_translate"])
+    @pytest.mark.parametrize("type_", ["translate", "matrix-translate"])
     def test_min_parameters(self, dummy_files: dict[str, pathlib.Path], type_) -> None:
         """Testing running with bare minimum arguments."""
         sys.argv = [
@@ -80,7 +80,7 @@ class TestParseArgs:
                 data_file=dummy_files["data_file"],
                 translation_file=dummy_files["translation_file"],
             )
-        elif type_ == "matrix_translate":
+        elif type_ == "matrix-translate":
             expected = MatrixTranslationArgs(
                 data_file=dummy_files["data_file"],
                 translation_file=dummy_files["translation_file"],
@@ -96,7 +96,7 @@ class TestParseArgs:
         "fixture, name",
         [
             ("translate_config", "translate-config"),
-            ("matrix_translate_config", "matrix_translate-config"),
+            ("matrix_translate_config", "matrix-translate-config"),
         ],
     )
     def test_load_config(self, request: pytest.FixtureRequest, fixture, name):
@@ -159,7 +159,7 @@ class TestParseArgs:
         # Testing abreviated names too
         sys.argv = [
             "caf.toolkit",
-            "matrix_translate",
+            "matrix-translate",
             "--o",
             str(expected.output_file),
             "--from_column",


### PR DESCRIPTION
Removed traceback details from CLI error messages and added env variable to re-enable them.

Describe Changes
---
- Added optional "TOOLKIT_TRACEBACK" environment variable to flag whether to display full error message tracebacks or not (default).
- Added `getenv_bool` function for converting environment variable values to boolean

Task Checklist
----
- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Have integration tests been added (if applicable, to test modules of functionality)
- [x] Updated RELEASE.md to reflect changes in PR
- [x] ~~Have new dependencies been added?~~
  - [ ] ~~Have they been added to either `requirements.txt` or `requirements_dev.txt`.~~
  - [ ] ~~Have they been added to `pyproject.toml`~~
