### PR TITLE
Add helpers to filter wide Pandas matrices by index / columns

### DIFF
--- a/docs/pandas_utils.rst
+++ b/docs/pandas_utils.rst
@@ -7,3 +7,4 @@ pandas_utils sub package
     df_handling
     numpy_conversions
     utility
+    wide_df_handling

--- a/docs/wide_df_handling.rst
+++ b/docs/wide_df_handling.rst
@@ -1,0 +1,5 @@
+wide_df_handling
+===========
+
+.. automodapi:: pandas_utils.wide_df_handling
+    :no-heading:

--- a/src/caf/toolkit/pandas_utils/__init__.py
+++ b/src/caf/toolkit/pandas_utils/__init__.py
@@ -2,3 +2,4 @@
 from caf.toolkit.pandas_utils.df_handling import *
 from caf.toolkit.pandas_utils.numpy_conversions import *
 from caf.toolkit.pandas_utils.utility import cast_to_common_type
+from caf.toolkit.pandas_utils.wide_df_handling import *

--- a/src/caf/toolkit/pandas_utils/df_handling.py
+++ b/src/caf/toolkit/pandas_utils/df_handling.py
@@ -2,8 +2,9 @@
 """Helper functions for handling pandas DataFrames."""
 # Built-Ins
 import functools
+import operator
 import warnings
-from typing import Any, Generator, Mapping, Optional
+from typing import Any, Generator, Mapping, Optional, Callable
 
 # Third Party
 import numpy as np
@@ -319,6 +320,89 @@ def filter_df(
             )
 
     return return_df
+
+
+def get_wide_mask(df: pd.DataFrame,
+                  selection: list[Any] = None,
+                  col_select: list[Any] = None,
+                  index_select: list[Any] = None,
+                  join_fn: Callable = operator.and_
+                  ) -> np.ndarray:
+    """
+    Generate an index/column mask for a wide matrix.
+
+    Helper function to make selecting combinations of zones in a wide matrix
+    eaiser. The index and column selections can be set individually using
+     `col_select` and `index_select`, or set to the same value using
+     `selection`.
+
+    Parameters
+    ----------
+    df:
+        The dataframe to generate the mask for.
+
+    selection:
+        The IDs to select in both the columns and index. If this value
+        is set it will overwrite anything passed into `col_select` and
+        `index_select`.
+
+    col_select:
+        The IDs to select in the columns. This value is ignored if
+        `selection` is set.
+
+    index_select:
+        The IDs to select in the index. This value is ignored if
+        `selection` is set.
+
+    join_fn:
+        Individual masks are generated for the index and columns. This
+        function is used to combine the two masks. By default, a bitwise AND
+        is used, meaning the final mask will only return `True` where both
+        the index and column masks overlap. See pythons builtin operator
+        library for more built-in options.
+
+    Returns
+    -------
+    mask:
+        A mask of true and false values. Will be the same shape as df.
+    """
+    # Validate input args
+    if selection is None:
+        if col_select is None or index_select is None:
+            raise ValueError(
+                "If zones is not set, both col_select and row_zones need "
+                "to be set."
+            )
+    else:
+        col_select = selection
+        index_select = selection
+
+    # Try and cast to the correct types for rows/cols
+    try:
+        # Assume columns are strings if they are an object
+        col_dtype = df.columns.dtype
+        col_dtype = str if col_dtype == object else col_dtype
+        col_select = np.array(col_select, col_dtype)
+    except ValueError as exc:
+        raise ValueError(
+            "Cannot cast the col_select to the required dtype to match the "
+            f"dtype of the given df columns. Tried to cast to: {df.columns.dtype}"
+        ) from exc
+
+    try:
+        index_select = np.array(index_select, df.index.dtype)
+    except ValueError as exc:
+        raise ValueError(
+            "Cannot cast the index_select to the required dtype to match the "
+            f"dtype of the given df index. Tried to cast to: {df.index.dtype}"
+        ) from exc
+
+    # Create square masks for the rows and cols
+    col_mask = np.broadcast_to(df.columns.isin(col_select), df.shape)
+    index_mask = np.broadcast_to(df.index.isin(index_select), df.shape).T
+
+    # Combine to get the full mask
+    return join_fn(col_mask, index_mask)
 
 
 def str_join_cols(

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -50,34 +50,6 @@ def get_wide_mask(
      `col_select` and `index_select`, or set to the same value using
      `selection`.
 
-    Typical usage for travel demand matrices
-    >>> df = pd.DataFrame(np.arange(16).reshape(4, 4))
-    >>> df
-        0   1   2   3
-    0   0   1   2   3
-    1   4   5   6   7
-    2   8   9  10  11
-    3  12  13  14  15
-    >>> get_wide_mask(df, selection=[0, 1])
-    array([[ True,  True, False, False],
-           [ True,  True, False, False],
-           [False, False, False, False],
-           [False, False, False, False]])
-
-     It's possible to select differently for the index and columns
-    >>> get_wide_mask(df, col_select=[0, 1], index_select=[1, 2, 3])
-    array([[False, False, False, False],
-           [ True,  True, False, False],
-           [ True,  True, False, False],
-           [ True,  True, False, False]])
-
-    The operator for joining the column and index selections can also be changed
-    >>> get_wide_mask(df, selection=[0, 1], join_fn=operator.or_)
-    array([[ True,  True,  True,  True],
-           [ True,  True,  True,  True],
-           [ True,  True, False, False],
-           [ True,  True, False, False]])
-
     Parameters
     ----------
     df:
@@ -112,6 +84,40 @@ def get_wide_mask(
     --------
     :func:`get_wide_internal_only_mask`
     :func:`get_wide_all_external_mask`
+
+    Examples
+    --------
+    Typical usage for travel demand matrices
+
+    >>> df = pd.DataFrame(np.arange(16).reshape(4, 4))
+    >>> df
+        0   1   2   3
+    0   0   1   2   3
+    1   4   5   6   7
+    2   8   9  10  11
+    3  12  13  14  15
+
+    >>> get_wide_mask(df, selection=[0, 1])
+    array([[ True,  True, False, False],
+           [ True,  True, False, False],
+           [False, False, False, False],
+           [False, False, False, False]])
+
+     It's possible to select differently for the index and columns
+
+    >>> get_wide_mask(df, col_select=[0, 1], index_select=[1, 2, 3])
+    array([[False, False, False, False],
+           [ True,  True, False, False],
+           [ True,  True, False, False],
+           [ True,  True, False, False]])
+
+    The operator for joining the column and index selections can also be changed
+    
+    >>> get_wide_mask(df, selection=[0, 1], join_fn=operator.or_)
+    array([[ True,  True,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True, False, False],
+           [ True,  True, False, False]])
     """
     # Validate input args
     if selection is None:

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -132,7 +132,9 @@ def get_wide_mask(
 
     # Validate matrix shape
     if len(df.shape) != 2 or df.shape[0] != df.shape[1]:
-        raise ValueError(f"Only square matrices with 2 dimensions are supported. Got: {df.shape}")
+        raise ValueError(
+            f"Only square matrices with 2 dimensions are supported. Got: {df.shape}"
+        )
 
     # Try match dtypes in rows and cols
     if df.columns.dtype != type(col_select):

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -124,7 +124,10 @@ def get_wide_mask(
     if select is None:
         if col_select is None or index_select is None:
             raise ValueError(
-                "If selection is not set, both col_select and row_zones need to be set."
+                "If selection is not set, both col_select and row_zones need to be set. "
+                "If you're interested in this function being able to filter on just rows "
+                "or columns, please register your interest by commenting on this issue: "
+                "https://github.com/Transport-for-the-North/caf.toolkit/issues/131"
             )
     else:
         col_select = select

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -42,13 +42,12 @@ def get_wide_mask(
     index_select: Optional[list[Any]] = None,
     join_fn: Callable = operator.and_,
 ) -> np.ndarray:
-    """
-    Generate an index/column mask for a wide Pandas matrix.
+    """Generate an index/column mask for a wide Pandas matrix.
 
     Helper function to make selecting combinations of zones in a wide matrix
     easier. The index and column selections can be set individually using
-     `col_select` and `index_select`, or set to the same value using
-     `selection`.
+    `col_select` and `index_select`, or set to the same value using
+    `selection`.
 
     Parameters
     ----------
@@ -77,7 +76,7 @@ def get_wide_mask(
 
     Returns
     -------
-    mask:
+    np.ndarray:
         A mask of True and False values. Will be the same shape as `df`.
 
     See Also
@@ -103,7 +102,7 @@ def get_wide_mask(
            [False, False, False, False],
            [False, False, False, False]])
 
-     It's possible to select differently for the index and columns
+    It's possible to select differently for the index and columns
 
     >>> get_wide_mask(df, col_select=[0, 1], index_select=[1, 2, 3])
     array([[False, False, False, False],
@@ -112,7 +111,7 @@ def get_wide_mask(
            [ True,  True, False, False]])
 
     The operator for joining the column and index selections can also be changed
-    
+
     >>> get_wide_mask(df, selection=[0, 1], join_fn=operator.or_)
     array([[ True,  True,  True,  True],
            [ True,  True,  True,  True],
@@ -165,29 +164,6 @@ def get_wide_internal_only_mask(
 
     To extract values from the given df perform `df * mask`.
 
-    Internal zones in travel demand matrices tend to be the first in the matrix
-    >>> df = pd.DataFrame(np.full((4, 4), 5))
-    >>> df
-       0  1  2  3
-    0  5  5  5  5
-    1  5  5  5  5
-    2  5  5  5  5
-    3  5  5  5  5
-    >>> mask = get_wide_internal_only_mask(df, selection=[0, 1])
-    >>> mask
-    array([[ True,  True, False, False],
-           [ True,  True, False, False],
-           [False, False, False, False],
-           [False, False, False, False]])
-
-    Values can be extracted using multiplication
-    >>> df * mask
-       0  1  2  3
-    0  5  5  0  0
-    1  5  5  0  0
-    2  0  0  0  0
-    3  0  0  0  0
-
     Parameters
     ----------
     df:
@@ -205,6 +181,34 @@ def get_wide_internal_only_mask(
     --------
     :func:`get_wide_mask`
     :func:`get_wide_all_external_mask`
+
+    Examples
+    --------
+    Internal zones in travel demand matrices tend to be the first in the matrix
+
+    >>> df = pd.DataFrame(np.full((4, 4), 5))
+    >>> df
+       0  1  2  3
+    0  5  5  5  5
+    1  5  5  5  5
+    2  5  5  5  5
+    3  5  5  5  5
+
+    >>> mask = get_wide_internal_only_mask(df, selection=[0, 1])
+    >>> mask
+    array([[ True,  True, False, False],
+           [ True,  True, False, False],
+           [False, False, False, False],
+           [False, False, False, False]])
+
+    Values can be extracted using multiplication
+
+    >>> df * mask
+       0  1  2  3
+    0  5  5  0  0
+    1  5  5  0  0
+    2  0  0  0  0
+    3  0  0  0  0
     """
     return get_wide_mask(df=df, selection=selection, join_fn=operator.and_)
 
@@ -221,29 +225,6 @@ def get_wide_all_external_mask(
     "external_to_internal", and "internal to external" area.
 
     To extract values from the given df perform `df * mask`.
-
-    External zones in travel demand matrices tend to be the last in the matrix
-    >>> df = pd.DataFrame(np.full((4, 4), 5))
-    >>> df
-       0  1  2  3
-    0  5  5  5  5
-    1  5  5  5  5
-    2  5  5  5  5
-    3  5  5  5  5
-    >>> mask = get_wide_all_external_mask(df, selection=[2, 3])
-    >>> mask
-    array([[False, False,  True,  True],
-           [False, False,  True,  True],
-           [ True,  True,  True,  True],
-           [ True,  True,  True,  True]])
-
-    Values can be extracted using multiplication
-    >>> df * mask
-       0  1  2  3
-    0  0  0  5  5
-    1  0  0  5  5
-    2  5  5  5  5
-    3  5  5  5  5
 
     Parameters
     ----------
@@ -262,6 +243,34 @@ def get_wide_all_external_mask(
     --------
     :func:`get_wide_mask`
     :func:`get_wide_internal_only_mask`
+
+    Examples
+    --------
+    External zones in travel demand matrices tend to be the last in the matrix
+
+    >>> df = pd.DataFrame(np.full((4, 4), 5))
+    >>> df
+       0  1  2  3
+    0  5  5  5  5
+    1  5  5  5  5
+    2  5  5  5  5
+    3  5  5  5  5
+
+    >>> mask = get_wide_all_external_mask(df, selection=[2, 3])
+    >>> mask
+    array([[False, False,  True,  True],
+           [False, False,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True,  True,  True]])
+
+    Values can be extracted using multiplication
+
+    >>> df * mask
+       0  1  2  3
+    0  0  0  5  5
+    1  0  0  5  5
+    2  5  5  5  5
+    3  5  5  5  5
     """
     return get_wide_mask(df=df, selection=selection, join_fn=operator.or_)
 
@@ -278,20 +287,6 @@ def wide_matrix_internal_external_report(
     internal-internal, internal-external, external-internal, external-external.
     Row and columns totals are also presented.
 
-    >>> df = pd.DataFrame(np.arange(25).reshape(5, 5))
-    >>> df
-        0   1   2   3   4
-    0   0   1   2   3   4
-    1   5   6   7   8   9
-    2  10  11  12  13  14
-    3  15  16  17  18  19
-    4  20  21  22  23  24
-    >>> wide_matrix_internal_external_report(df, [0, 1, 2], [3, 4])
-              internal  external  total
-    internal      54.0      51.0  105.0
-    external     111.0      84.0  195.0
-    total        165.0     135.0  300.0
-
     Parameters
     ----------
     df:
@@ -307,6 +302,23 @@ def wide_matrix_internal_external_report(
     -------
     report:
         A report of internal and external demand in df.
+
+    Examples
+    --------
+    >>> df = pd.DataFrame(np.arange(25).reshape(5, 5))
+    >>> df
+        0   1   2   3   4
+    0   0   1   2   3   4
+    1   5   6   7   8   9
+    2  10  11  12  13  14
+    3  15  16  17  18  19
+    4  20  21  22  23  24
+
+    >>> wide_matrix_internal_external_report(df, [0, 1, 2], [3, 4])
+              internal  external  total
+    internal      54.0      51.0  105.0
+    external     111.0      84.0  195.0
+    total        165.0     135.0  300.0
     """
     # Warn if overlap of internal and external selection
     if len(overlap := set(int_selection) & set(ext_selection)):

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -4,7 +4,7 @@
 import logging
 import operator
 import warnings
-from typing import Any, Callable, Optional, Collection
+from typing import Any, Callable, Collection, Optional
 
 # Third Party
 import numpy as np

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -1,0 +1,352 @@
+# -*- coding: utf-8 -*-
+"""Helper functions for handling wide pandas DataFrames, usually as demand matrices."""
+# Built-Ins
+import logging
+import operator
+import warnings
+from typing import Any, Callable, Optional, Collection
+
+# Third Party
+import numpy as np
+import pandas as pd
+import pandas.api.types
+
+# pylint: disable=import-error,wrong-import-position
+
+# pylint: enable=import-error,wrong-import-position
+
+# # # CONSTANTS # # #
+LOG = logging.getLogger(__name__)
+
+# # # CLASSES # # #
+
+
+# # # FUNCTIONS # # #
+def _guess_pandas_dtype(things):
+    """Get the type of pandas object, avoiding object type."""
+    # TODO(BT) Figure out a better way to do this. I don't like this way, but
+    #  it avoids all the trouble you get into with pandas telling you that a
+    #  column of integers is "object" type, but "object" type is also used
+    #  to describe strings...
+    if pandas.api.types.is_string_dtype(things):
+        return str
+    if pandas.api.types.is_numeric_dtype(things):
+        return things.dtype
+    raise ValueError("Can't figure out type!")
+
+
+def get_wide_mask(
+    df: pd.DataFrame,
+    selection: Optional[list[Any]] = None,
+    col_select: Optional[list[Any]] = None,
+    index_select: Optional[list[Any]] = None,
+    join_fn: Callable = operator.and_,
+) -> np.ndarray:
+    """
+    Generate an index/column mask for a wide Pandas matrix.
+
+    Helper function to make selecting combinations of zones in a wide matrix
+    easier. The index and column selections can be set individually using
+     `col_select` and `index_select`, or set to the same value using
+     `selection`.
+
+    Typical usage for travel demand matrices
+    >>> df = pd.DataFrame(np.arange(16).reshape(4, 4))
+    >>> df
+        0   1   2   3
+    0   0   1   2   3
+    1   4   5   6   7
+    2   8   9  10  11
+    3  12  13  14  15
+    >>> get_wide_mask(df, selection=[0, 1])
+    array([[ True,  True, False, False],
+           [ True,  True, False, False],
+           [False, False, False, False],
+           [False, False, False, False]])
+
+     It's possible to select differently for the index and columns
+    >>> get_wide_mask(df, col_select=[0, 1], index_select=[1, 2, 3])
+    array([[False, False, False, False],
+           [ True,  True, False, False],
+           [ True,  True, False, False],
+           [ True,  True, False, False]])
+
+    The operator for joining the column and index selections can also be changed
+    >>> get_wide_mask(df, selection=[0, 1], join_fn=operator.or_)
+    array([[ True,  True,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True, False, False],
+           [ True,  True, False, False]])
+
+    Parameters
+    ----------
+    df:
+        The dataframe to generate the mask for.
+
+    selection:
+        The IDs to select in both the columns and index. If this value
+        is set it will overwrite anything passed into `col_select` and
+        `index_select`.
+
+    col_select:
+        The IDs to select in the columns. This value is ignored if
+        `selection` is set.
+
+    index_select:
+        The IDs to select in the index. This value is ignored if
+        `selection` is set.
+
+    join_fn:
+        Individual masks are generated for the index and columns. This
+        function is used to combine the two masks. By default, a bitwise AND
+        is used, meaning the final mask will only return `True` where both
+        the index and column masks overlap. See pythons builtin operator
+        library for more built-in options.
+
+    Returns
+    -------
+    mask:
+        A mask of True and False values. Will be the same shape as `df`.
+
+    See Also
+    --------
+    :func:`get_wide_internal_only_mask`
+    :func:`get_wide_all_external_mask`
+    """
+    # Validate input args
+    if selection is None:
+        if col_select is None or index_select is None:
+            raise ValueError(
+                "If selection is not set, both col_select and row_zones need to be set."
+            )
+    else:
+        col_select = selection
+        index_select = selection
+
+    # Try match dtypes in rows and cols
+    if df.columns.dtype != type(col_select):
+        col_select = np.array(col_select, dtype=_guess_pandas_dtype(df.columns))  # type: ignore
+    if df.index.dtype != type(index_select):
+        index_select = np.array(index_select, dtype=_guess_pandas_dtype(df.index))  # type: ignore
+
+    # Create square masks for the rows and cols
+    col_mask = np.broadcast_to(df.columns.isin(col_select), df.shape)
+    index_mask = np.broadcast_to(df.index.isin(index_select), df.shape).T
+
+    # Warn the user if nothing has matched
+    if col_mask.sum() == 0:
+        warnings.warn(
+            "No columns matched the given selection. Please check values and datatypes."
+        )
+    if index_mask.sum() == 0:
+        warnings.warn(
+            "No index matched the given selection. Please check values and datatypes."
+        )
+
+    # Combine to get the full mask
+    return join_fn(col_mask, index_mask)
+
+
+def get_wide_internal_only_mask(
+    df: pd.DataFrame,
+    selection: list[Any],
+) -> np.ndarray:
+    """Generate an internal only mask for a wide matrix.
+
+    This is a common operation in wide travel demand matrices. When a matrix
+    contains both "internal" and "external" demand, this function can be used
+    to generate a mask that selects the "internal to internal" area only.
+
+    To extract values from the given df perform `df * mask`.
+
+    Internal zones in travel demand matrices tend to be the first in the matrix
+    >>> df = pd.DataFrame(np.full((4, 4), 5))
+    >>> df
+       0  1  2  3
+    0  5  5  5  5
+    1  5  5  5  5
+    2  5  5  5  5
+    3  5  5  5  5
+    >>> mask = get_wide_internal_only_mask(df, selection=[0, 1])
+    >>> mask
+    array([[ True,  True, False, False],
+           [ True,  True, False, False],
+           [False, False, False, False],
+           [False, False, False, False]])
+
+    Values can be extracted using multiplication
+    >>> df * mask
+       0  1  2  3
+    0  5  5  0  0
+    1  5  5  0  0
+    2  0  0  0  0
+    3  0  0  0  0
+
+    Parameters
+    ----------
+    df:
+        The Pandas DataFrame to generate the mask for.
+
+    selection:
+        A list of index/column identifiers that should be selected.
+
+    Returns
+    -------
+    mask:
+        A mask of True and False values. Will be the same shape as `df`.
+
+    See Also
+    --------
+    :func:`get_wide_mask`
+    :func:`get_wide_all_external_mask`
+    """
+    return get_wide_mask(df=df, selection=selection, join_fn=operator.and_)
+
+
+def get_wide_all_external_mask(
+    df: pd.DataFrame,
+    selection: list[Any],
+) -> np.ndarray:
+    """Generate an external only mask for a wide matrix.
+
+    This is a common operation in wide travel demand matrices. When a matrix
+    contains both "internal" and "external" demand, this function can be used
+    to generate a mask that selects the "external to external",
+    "external_to_internal", and "internal to external" area.
+
+    To extract values from the given df perform `df * mask`.
+
+    External zones in travel demand matrices tend to be the last in the matrix
+    >>> df = pd.DataFrame(np.full((4, 4), 5))
+    >>> df
+       0  1  2  3
+    0  5  5  5  5
+    1  5  5  5  5
+    2  5  5  5  5
+    3  5  5  5  5
+    >>> mask = get_wide_all_external_mask(df, selection=[2, 3])
+    >>> mask
+    array([[False, False,  True,  True],
+           [False, False,  True,  True],
+           [ True,  True,  True,  True],
+           [ True,  True,  True,  True]])
+
+    Values can be extracted using multiplication
+    >>> df * mask
+       0  1  2  3
+    0  0  0  5  5
+    1  0  0  5  5
+    2  5  5  5  5
+    3  5  5  5  5
+
+    Parameters
+    ----------
+    df:
+        The Pandas DataFrame to generate the mask for.
+
+    selection:
+        A list of index/column identifiers that should be selected.
+
+    Returns
+    -------
+    mask:
+        A mask of True and False values. Will be the same shape as `df`.
+
+    See Also
+    --------
+    :func:`get_wide_mask`
+    :func:`get_wide_internal_only_mask`
+    """
+    return get_wide_mask(df=df, selection=selection, join_fn=operator.or_)
+
+
+def wide_matrix_internal_external_report(
+    df: pd.DataFrame,
+    int_selection: Collection[Any],
+    ext_selection: Collection[Any],
+) -> pd.DataFrame:
+    """Generate a matrix report of value totals internal and externally.
+
+    Generates a 3x3 Pandas DataFrame detailing the total of values across 4
+    categories:
+    internal-internal, internal-external, external-internal, external-external.
+    Row and columns totals are also presented.
+
+    >>> df = pd.DataFrame(np.arange(25).reshape(5, 5))
+    >>> df
+        0   1   2   3   4
+    0   0   1   2   3   4
+    1   5   6   7   8   9
+    2  10  11  12  13  14
+    3  15  16  17  18  19
+    4  20  21  22  23  24
+    >>> wide_matrix_internal_external_report(df, [0, 1, 2], [3, 4])
+              internal  external  total
+    internal      54.0      51.0  105.0
+    external     111.0      84.0  195.0
+    total        165.0     135.0  300.0
+
+    Parameters
+    ----------
+    df:
+        The dataframe to generate the report.
+
+    int_selection:
+        A list of the column and index identifiers to mark as "internal".
+
+    ext_selection:
+        A list of the column and index identifiers to mark as "external".
+
+    Returns
+    -------
+    report:
+        A report of internal and external demand in df.
+    """
+    # Warn if overlap of internal and external selection
+    if len(overlap := set(int_selection) & set(ext_selection)):
+        warnings.warn(
+            "internal_selection and external_selection having overlapping values. "
+            "The produced report will contain double counting and could be "
+            f"unreliable. {overlap=}"
+        )
+
+    # Warn if not all given index and column values are included in the given selection
+    df_ids = set(df.index.to_list()) | set(df.columns.to_list())
+    select_ids = set(int_selection) | set(ext_selection)
+    if len(missing := df_ids - select_ids):
+        warnings.warn(
+            "The given selection of internal and external values do not contain "
+            f"all values in the dataframe index and columns. {missing=}"
+        )
+
+    # Build the initial report
+    index = pd.Index(["internal", "external"])
+    report = pd.DataFrame(index=index, columns=index, data=np.zeros((len(index), len(index))))
+
+    # Build the kwargs to iterate over
+    report_kwargs = {
+        ("internal", "internal"): {"index_select": int_selection, "col_select": int_selection},
+        ("internal", "external"): {"index_select": int_selection, "col_select": ext_selection},
+        ("external", "internal"): {"index_select": ext_selection, "col_select": int_selection},
+        ("external", "external"): {"index_select": ext_selection, "col_select": ext_selection},
+    }
+
+    # Build the report from the kwargs
+    for (row_idx, col_idx), kwargs in report_kwargs.items():
+        # TODO(BT): There is a way around ignoring kwarg types, but it feels like
+        #  a lot of faff. See here:
+        #  https://stackoverflow.com/questions/66120871/incompatible-type-in-mypy-seen-using-kwargs
+        mask = get_wide_mask(
+            df=df,
+            join_fn=operator.and_,
+            **kwargs,  # type: ignore
+        )
+        total = (df * mask).to_numpy().sum()
+
+        # Feel like this indexing is backwards...
+        report.loc[row_idx, col_idx] = total
+
+    # Add a total row and column
+    report["total"] = report.values.sum(axis=1)
+    report.loc["total"] = report.values.sum(axis=0)
+    return report

--- a/src/caf/toolkit/pandas_utils/wide_df_handling.py
+++ b/src/caf/toolkit/pandas_utils/wide_df_handling.py
@@ -314,6 +314,12 @@ def wide_matrix_internal_external_report(
     report:
         A report of internal and external demand in df.
 
+    Warns
+    -----
+    UserWarning:
+        If `internal_selection` and `external_selection` do not contain all the values
+        listed in `df`, OR they have overlapping values - leading to double counting.
+
     Examples
     --------
     >>> df = pd.DataFrame(np.arange(25).reshape(5, 5))

--- a/tests/pandas_utils/test_wide_df_handling.py
+++ b/tests/pandas_utils/test_wide_df_handling.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+"""Tests for the {} module"""
+# Built-Ins
+import dataclasses
+import operator
+from typing import Any, Callable
+
+# Third Party
+import numpy as np
+import pandas as pd
+import pytest
+
+# Local Imports
+from caf.toolkit import pandas_utils as pd_utils
+
+# # # CONSTANTS # # #
+
+
+# # # CLASSES # # #
+@dataclasses.dataclass
+class WideMatrixData:
+    """Store testing data for a wide matrix.
+
+    Some helper functions to replicate the functions we're testing at their
+    most basic. This should make the tests more readable.
+    """
+
+    matrix: pd.DataFrame
+
+    def index_mask(self, selection: list[int]) -> np.ndarray:
+        """Get the mask for index matching in the shape of self.matrix."""
+        mask = np.isin(self.matrix.index.to_numpy(), selection)
+        return np.broadcast_to(mask, self.matrix.shape).T
+
+    def col_mask(self, selection: list[int]) -> np.ndarray:
+        """Get the mask for col matching in the shape of self.matrix."""
+        mask = np.isin(self.matrix.columns.to_numpy(), selection)
+        return np.broadcast_to(mask, self.matrix.shape)
+
+    def full_mask(
+        self,
+        index_select: list[int],
+        col_select: list[int],
+        join_fn: Callable,
+    ) -> np.ndarray:
+        """Get the full mask of rows and columns in the shape of self.matrix."""
+        return join_fn(self.col_mask(col_select), self.index_mask(index_select))
+
+
+@dataclasses.dataclass
+class ReportMatrixData(WideMatrixData):
+    """Store testing data for the wide_matrix_internal_external_report()"""
+
+    expected_report: pd.DataFrame
+    int_select: list[int]
+    ext_select: list[int]
+
+    def get_kwargs(self) -> dict[str, Any]:
+        """Produce a kwarg dict. Prevents repeated code."""
+        return {
+            "df": self.matrix,
+            "int_select": self.int_select,
+            "ext_select": self.ext_select,
+        }
+
+
+# # # FIXTURES # # #
+def random_matrix(shape: tuple[int,]) -> pd.DataFrame:
+    """Produce a random matrix of a given shape"""
+    rng = np.random.default_rng()
+    return pd.DataFrame(rng.random(shape))
+
+
+@pytest.fixture(name="random_square_matrix", scope="function")
+def fixture_random_square_matrix(request) -> WideMatrixData:
+    """Fixture to create random matrix of set dimensions"""
+    shape = (request.param, request.param)
+    return WideMatrixData(matrix=random_matrix(shape))
+
+
+@pytest.fixture(name="non_square_matrix", scope="module")
+def fixture_non_square_matrix(request) -> WideMatrixData:
+    """Fixture to create random matrix of set dimensions"""
+    return WideMatrixData(matrix=random_matrix(request.param))
+
+
+# # # TESTS # # #
+class TestGetWideMask:
+    """Tests for get_wide_mask()"""
+
+    # TODO(BT): Add tests for datatypes. Different + fuzzy matching. Hoping some
+    #  good test cases come out of real usage
+
+    @pytest.mark.parametrize("random_square_matrix", (5, 11, 13), indirect=True)
+    @pytest.mark.parametrize("select", [[0], [1, 2], [1, 3, 4]])
+    def test_same_select_square_correct(
+        self,
+        random_square_matrix: WideMatrixData,
+        select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.and_
+        result = pd_utils.get_wide_mask(
+            random_square_matrix.matrix, select=select, join_fn=join_fn
+        )
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=select,
+            col_select=select,
+            join_fn=join_fn,
+        )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("random_square_matrix", (5, 11, 13), indirect=True)
+    @pytest.mark.parametrize("index_select", [[0], [1, 2], [1, 3, 4]])
+    @pytest.mark.parametrize("col_select", [[0], [1, 2], [1, 3, 4]])
+    def test_different_select_square_correct(
+        self,
+        random_square_matrix: WideMatrixData,
+        index_select: list[int],
+        col_select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.and_
+        result = pd_utils.get_wide_mask(
+            random_square_matrix.matrix,
+            col_select=col_select,
+            index_select=index_select,
+            join_fn=join_fn,
+        )
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=index_select,
+            col_select=col_select,
+            join_fn=join_fn,
+        )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("random_square_matrix", (5, 11, 13), indirect=True)
+    @pytest.mark.parametrize("select", [[0], [1, 2], [1, 3, 4]])
+    @pytest.mark.parametrize("join_fn", [operator.or_, operator.and_])
+    def test_join_fn_square_correct(
+        self,
+        random_square_matrix: WideMatrixData,
+        select: list[int],
+        join_fn: Callable,
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        result = pd_utils.get_wide_mask(
+            random_square_matrix.matrix, select=select, join_fn=join_fn
+        )
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=select,
+            col_select=select,
+            join_fn=join_fn,
+        )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("non_square_matrix", ((6, 5), (11, 13), (7,)), indirect=True)
+    def test_non_square_error(self, non_square_matrix: WideMatrixData):
+        """Test an error is raised when the matrix is not square."""
+        select = [1, 2]
+        join_fn = operator.and_
+
+        msg = "Only square matrices with 2 dimensions are supported"
+        with pytest.raises(ValueError, match=msg):
+            pd_utils.get_wide_mask(non_square_matrix.matrix, select=select, join_fn=join_fn)
+
+    @pytest.mark.parametrize("random_square_matrix", [5], indirect=True)
+    def test_bad_input_error(self, random_square_matrix: WideMatrixData):
+        """Test an error is raised when bad input is used."""
+        select = [1, 2]
+        join_fn = operator.and_
+
+        msg = "If selection is not set, both col_select and row_zones need to be set"
+        with pytest.raises(ValueError, match=msg):
+            pd_utils.get_wide_mask(
+                random_square_matrix.matrix, col_select=select, join_fn=join_fn
+            )
+
+        with pytest.raises(ValueError, match=msg):
+            pd_utils.get_wide_mask(
+                random_square_matrix.matrix, index_select=select, join_fn=join_fn
+            )
+
+    @pytest.mark.parametrize("random_square_matrix", [5], indirect=True)
+    @pytest.mark.parametrize("col_select", [[5], [7, 11]])
+    @pytest.mark.parametrize("index_select", [[0], [1, 2], [1, 3, 4]])
+    def test_no_col_match_warning(
+        self,
+        random_square_matrix: WideMatrixData,
+        index_select: list[int],
+        col_select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.and_
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=index_select,
+            col_select=col_select,
+            join_fn=join_fn,
+        )
+
+        msg = "No columns matched"
+        with pytest.warns(UserWarning, match=msg):
+            result = pd_utils.get_wide_mask(
+                random_square_matrix.matrix,
+                col_select=col_select,
+                index_select=index_select,
+                join_fn=join_fn,
+            )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("random_square_matrix", [5], indirect=True)
+    @pytest.mark.parametrize("index_select", [[5], [7, 11]])
+    @pytest.mark.parametrize("col_select", [[0], [1, 2], [1, 3, 4]])
+    def test_no_index_match_warning(
+        self,
+        random_square_matrix: WideMatrixData,
+        index_select: list[int],
+        col_select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.and_
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=index_select,
+            col_select=col_select,
+            join_fn=join_fn,
+        )
+
+        msg = "No index matched"
+        with pytest.warns(UserWarning, match=msg):
+            result = pd_utils.get_wide_mask(
+                random_square_matrix.matrix,
+                col_select=col_select,
+                index_select=index_select,
+                join_fn=join_fn,
+            )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestInternalExternalHelpers:
+    """Tests for get_wide_internal_only_mask() and get_wide_all_external_mask()"""
+
+    @pytest.mark.parametrize("random_square_matrix", (5, 11, 13), indirect=True)
+    @pytest.mark.parametrize("select", [[0], [1, 2], [1, 3, 4]])
+    def test_internal_correct(
+        self,
+        random_square_matrix: WideMatrixData,
+        select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.and_
+        result = pd_utils.get_wide_mask(
+            random_square_matrix.matrix, select=select, join_fn=join_fn
+        )
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=select,
+            col_select=select,
+            join_fn=join_fn,
+        )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+    @pytest.mark.parametrize("random_square_matrix", (5, 11, 13), indirect=True)
+    @pytest.mark.parametrize("select", [[0], [1, 2], [1, 3, 4]])
+    def test_external_correct(
+        self,
+        random_square_matrix: WideMatrixData,
+        select: list[int],
+    ):
+        """Test that we get the correct mask for a square matrix."""
+        join_fn = operator.or_
+        result = pd_utils.get_wide_mask(
+            random_square_matrix.matrix, select=select, join_fn=join_fn
+        )
+
+        # Expected result
+        expected = random_square_matrix.full_mask(
+            index_select=select,
+            col_select=select,
+            join_fn=join_fn,
+        )
+
+        # Should be a boolean array, so exactly the same
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestWideMatrixIntExtReport:
+    """Tests for wide_matrix_internal_external_report()"""
+
+    @pytest.fixture(name="correct_report", scope="class")
+    def fixture_correct_report(self) -> ReportMatrixData:
+        """Create an example of a correct input and report"""
+        int_select = [0, 1, 2]
+        ext_select = [3, 4]
+        mat = pd.DataFrame(np.arange(25).reshape(5, -1))
+
+        cols = ["internal", "external", "total"]
+        data = [[54, 51, 105], [111, 84, 195], [165, 135, 300]]
+        report = pd.DataFrame(data=data, index=cols, columns=cols).astype(float)
+        return ReportMatrixData(
+            matrix=mat,
+            expected_report=report,
+            int_select=int_select,
+            ext_select=ext_select,
+        )
+
+    @pytest.fixture(name="missing_bad_report", scope="class")
+    def fixture_missing_bad_report(self, correct_report: ReportMatrixData) -> ReportMatrixData:
+        """Create an example of a bad report where some df values are missed."""
+        int_select = [1, 2, 3]
+        ext_select = [4, 5]
+
+        report = pd.DataFrame(
+            data=[[108, 42, 150], [66, 24, 90], [174, 66, 240]],
+            index=correct_report.expected_report.index,
+            columns=correct_report.expected_report.columns,
+        ).astype(float)
+
+        return ReportMatrixData(
+            matrix=correct_report.matrix,
+            expected_report=report,
+            int_select=int_select,
+            ext_select=ext_select,
+        )
+
+    @pytest.fixture(name="overlap_bad_report", scope="class")
+    def fixture_overlap_bad_report(self, correct_report: ReportMatrixData) -> ReportMatrixData:
+        """Create an example of a bad report where some df values are counted twice."""
+        int_select = [0, 1, 2]
+        ext_select = [2, 3, 4]
+
+        report = pd.DataFrame(
+            data=[[54, 72, 126], [144, 162, 306], [198, 234, 432]],
+            index=correct_report.expected_report.index,
+            columns=correct_report.expected_report.columns,
+        ).astype(float)
+
+        return ReportMatrixData(
+            matrix=correct_report.matrix,
+            expected_report=report,
+            int_select=int_select,
+            ext_select=ext_select,
+        )
+
+    def test_correct(self, correct_report: ReportMatrixData):
+        """Test that the correct result is produced with correct data."""
+        result = pd_utils.wide_matrix_internal_external_report(**correct_report.get_kwargs())
+        pd.testing.assert_frame_equal(result, correct_report.expected_report)
+
+    def test_missing_warn(self, missing_bad_report: ReportMatrixData):
+        """Test that a warning is raised when not all values used."""
+        msg = "do not contain all values"
+        with pytest.warns(UserWarning, match=msg):
+            result = pd_utils.wide_matrix_internal_external_report(
+                **missing_bad_report.get_kwargs()
+            )
+        pd.testing.assert_frame_equal(result, missing_bad_report.expected_report)
+
+    def test_overlap_warn(self, overlap_bad_report: ReportMatrixData):
+        """Test that a warning is raised when not all values used."""
+        msg = "overlapping values"
+        with pytest.warns(UserWarning, match=msg):
+            result = pd_utils.wide_matrix_internal_external_report(
+                **overlap_bad_report.get_kwargs()
+            )
+        pd.testing.assert_frame_equal(result, overlap_bad_report.expected_report)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -153,7 +153,7 @@ class PandasTranslation:
         ret_val = pd.DataFrame(ret_val)
         ret_val[self.translation_from_col] = self.from_col.max() + 1
         ret_val[self.translation_factors_col] = 0
-        ret_val[self.translation_factors_col][0] = 1
+        ret_val.loc[0, self.translation_factors_col] = 1
         return ret_val.reindex(
             columns=[
                 self.translation_from_col,


### PR DESCRIPTION
Describe Changes
---
Add function(s) to split a wide pandas matrix by specific IDs easily - dealing with edge cases.
Particularly useful for splitting wide zonal matrices down to specific II, IE, EI, and EE areas.

Needed for data requests tool when cutting down matrices of data to a specific area.

fixes #120 

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [ ] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `pyproject.toml`
