### PR TITLE
Fixed bug in CostDistribution.from_file

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -26,4 +26,5 @@ Below, a brief summary of patches made since the previous version can be found.
 - Added `arguments.getenv_bool` function which gets an env variable and converts to bool
   with expected true (true, yes, y and 1) and false (false, no, n and 0) values
 - Bug fixes
-  - Removed all uses of `np.find_common_type()` as it is deprecated in newer versions of numpy 
+  - Removed all uses of `np.find_common_type()` as it is deprecated in newer versions of numpy
+  - Fixed an API change where `weighted_avg_col` was required when reading a `CostDistribution` from file

--- a/src/caf/toolkit/cost_utils.py
+++ b/src/caf/toolkit/cost_utils.py
@@ -65,7 +65,7 @@ class CostDistribution:
     max_col: str = "max"
     avg_col: str = "ave"
     trips_col: str = "trips"
-    weighted_avg_col: str = "weighted_ave"
+    weighted_avg_col: Optional[str] = "weighted_ave"
 
     # Ideas
     units: str = "km"
@@ -341,9 +341,13 @@ class CostDistribution:
         """
         if not os.path.isfile(filepath):
             raise ValueError(f"'{filepath}' is not the location of a file.")
-        use_cols = [min_col, max_col, avg_col, trips_col, weighted_avg_col]
+        use_cols = [min_col, max_col, avg_col, trips_col]
+        df = pd.read_csv(filepath)
+        if weighted_avg_col in df.columns:
+            use_cols.append(weighted_avg_col)
+
         return CostDistribution(
-            df=pd.read_csv(filepath, usecols=use_cols),
+            df=df[use_cols],
             min_col=min_col,
             max_col=max_col,
             avg_col=avg_col,

--- a/tests/test_cost_utils.py
+++ b/tests/test_cost_utils.py
@@ -458,10 +458,9 @@ class TestCostDistributionClassConstructors:
         """Test that the constructor can be called correctly from file"""
         input_and_results: CostDistClassResults = request.getfixturevalue(io_str)
 
+        input_and_results_df = input_and_results.df
         if drop_weighted:
-            input_and_results_df = input_and_results.df.drop(columns="weighted_ave")
-        else:
-            input_and_results_df = input_and_results.df
+            input_and_results_df = input_and_results_df.drop(columns="weighted_ave")
 
         # Create path and write out df
         filepath = tmp_path / "tld.csv"


### PR DESCRIPTION
The way the csv was read, weighted_ave_col wasn't optional as it should be.

Describe Changes
---
Fixes #125 

Task Checklist
----
- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Have integration tests been added (if applicable, to test modules of functionality)
- [x] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `pyproject.toml`
