### PR TITLE
Fix Numpy warnings in tests - compatibility for 2.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,3 +25,5 @@ Below, a brief summary of patches made since the previous version can be found.
   messages, by default only error text is output without the traceback
 - Added `arguments.getenv_bool` function which gets an env variable and converts to bool
   with expected true (true, yes, y and 1) and false (false, no, n and 0) values
+- Bug fixes
+  - Removed all uses of `np.find_common_type()` as it is deprecated in newer versions of numpy 

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -445,7 +445,7 @@ def numpy_vector_zone_translation(
 
     # ## CONVERT DTYPES ## #
     if translation_dtype is None:
-        translation_dtype = np.find_common_type([vector.dtype, translation.dtype], [])  # type: ignore
+        translation_dtype = np.promote_types(vector.dtype, translation.dtype)
     vector = _convert_dtypes(
         arr=vector,
         to_type=translation_dtype,

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -1355,12 +1355,6 @@ class TestPandasMatrixParams:
         result = translation.pandas_matrix_zone_translation(
             **pd_mat.input_kwargs(check_totals=check_totals)
         )
-
-        # Need to enforce types so this works in linux
-        # if sys.platform.startswith("linux"):
-        #     if any(x in ["int32", "int64"] for x in result.dtypes):
-        #         result = result.astype(pd_mat.expected_result.dtypes[1])
-
         pd.testing.assert_frame_equal(result, pd_mat.expected_result)
 
     def test_additional_index(self, pd_matrix_str: str, check_totals: bool, request):

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -700,7 +700,8 @@ def fixture_np_matrix_dtype(simple_np_int_translation: np.ndarray) -> NumpyMatri
             [16, 6, 14],
             [10, 6, 14],
             [19, 11, 23],
-        ]
+        ],
+        dtype=np.int32,
     )
     return NumpyMatrixResults(
         mat=mat,
@@ -1356,9 +1357,9 @@ class TestPandasMatrixParams:
         )
 
         # Need to enforce types so this works in linux
-        if sys.platform.startswith("linux"):
-            if any(x in ["int32", "int64"] for x in result.dtypes):
-                result = result.astype(pd_mat.expected_result.dtypes[1])
+        # if sys.platform.startswith("linux"):
+        #     if any(x in ["int32", "int64"] for x in result.dtypes):
+        #         result = result.astype(pd_mat.expected_result.dtypes[1])
 
         pd.testing.assert_frame_equal(result, pd_mat.expected_result)
 


### PR DESCRIPTION
Describe Changes
---

`np.find_common_type()` is deprecated in newer versions of numpy. This PR replaces all uses

Task Checklist
----
- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Have integration tests been added (if applicable, to test modules of functionality)
- [x] Updated RELEASE.md to reflect changes in PR
- [ ] Have new dependencies been added?
  - [ ] Have they been added to either `requirements.txt` or `requirements_dev.txt`.
  - [ ] Have they been added to `pyproject.toml`
