### PR TITLE
Docs: removed "documentation" from html title

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -119,6 +119,9 @@ html_static_path = ["_static"]
 
 html_theme_options = {
     "use_edit_page_button": True,
+    "logo": {
+        "text": f"{project} {version}",
+    },
     "icon_links": [
         {
             "name": "GitHub",


### PR DESCRIPTION
Describe Changes
---
Title was previously "caf.toolkit 0.8.0 documentation" and now is "caf.toolkit 0.8.0". The reason for this is when using full git descriptions for the latest or PR versions it would overlap the links.

Task Checklist
----
- [x] Have unittests been added (testing individual functions and their edge cases) - NA
- [x] Have integration tests been added (if applicable, to test modules of functionality) - NA
- [x] Have new dependencies been added to either `requirements.txt`, `requirements_dev.txt`, or `docs/requirements.txt`? - NA


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--154.org.readthedocs.build/en/154/

<!-- readthedocs-preview caftoolkit end -->