### PR TITLE
Handling boolean flags in ModelArguments

### DIFF
--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -152,13 +152,14 @@ def _replace_union(annotation: str) -> str:
 def parse_arg_details(annotation: str) -> tuple[type, bool, int | str | None]:
     """Attempt to get argument type from annotation text.
 
-    This only works with basic Python types (int, str, float and Path)
-    for any other types (str, False) will be returned.
+    This only works with basic Python types (int, str, float, bool and Path)
+    for any other types str will be returned.
 
     Parameters
     ----------
     annotation : str
-        Type annotation to be parsed e.g. 'list[int | str]'.
+        Type annotation to be parsed e.g. 'list[int | str]'. This can also
+        handle the repr of a type e.g. "<class 'bool'>".
 
     Returns
     -------

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -33,6 +33,10 @@ CORRECT_ANNOTATIONS = [
     ("tuple[int | str, int | str]", (str, False, 2)),
     ("list[int]", (int, False, "*")),
     ("Union[str, int]", (str, False, None)),
+    ("<class 'bool'>", (bool, False, None)),
+    ("<class 'int'>", (int, False, None)),
+    ("<class 'str'>", (str, False, None)),
+    ("<class 'float'>", (float, False, None)),
 ]
 
 


### PR DESCRIPTION
# Changes

Updated `ModelArguments`  to use "store_true", and "store_false", to have flags for boolean values instead of requiring true / false  arguments.

- Closes #175 

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [x] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--176.org.readthedocs.build/en/176/

<!-- readthedocs-preview caftoolkit end -->