### PR TITLE
[Feat]: added disabling config in ModelArguments subcommands

### DIFF
--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -93,7 +93,7 @@ def _parse_types(type_str: str) -> tuple[type, bool]:
     types = set()
     optional = False
     for type_ in type_str.split("|"):
-        match = re.match(r"(?:(\w+)\.)?(\w+)", type_.strip(), re.I)
+        match = re.match(r"(?:(\w+)\.)*(\w+)", type_.strip(), re.I)
         if match is None:
             warnings.warn(f"unexpect type format: '{type_}'", TypeAnnotationWarning)
             return str, optional

--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -321,7 +321,14 @@ class ModelArguments:
 
         return parser
 
-    def add_subcommands(self, subparsers: argparse._SubParsersAction, name: str, **kwargs):
+    def add_subcommands(
+        self,
+        subparsers: argparse._SubParsersAction,
+        name: str,
+        add_arguments: bool = True,
+        add_config: bool = True,
+        **kwargs,
+    ):
         """Add sub-commands for CLI arguments and config (if possible).
 
         Note: config sub-command won't be added if model provided to class
@@ -335,13 +342,26 @@ class ModelArguments:
         name : str
             Name of the sub-command to add, if config sub-command is
             added it will be called '{name}-config'.
+        add_arguments : bool
+            If True (default) adds sub-command called '{name}' with arguments.
+        add_config : bool
+            If True (default), and model given is a :class:`BaseConfig`,
+            adds sub-command called '{name}-config' with a single
+            config path argument.
         kwargs
             Keyword arguments to pass to `subparsers.add_parser`.
         """
-        parser = subparsers.add_parser(name, **kwargs)
-        self.add_arguments(parser)
+        if not add_arguments and not add_config:
+            raise ValueError(
+                "cannot add subcommands if add_arguments and add_config are both False."
+            )
 
-        if self._config:
+        parser = subparsers.add_parser(name, **kwargs)
+
+        if add_arguments:
+            self.add_arguments(parser)
+
+        if self._config and add_config:
             kwargs.pop("help", None)
             parser = subparsers.add_parser(
                 f"{name}-config", help=f"run {name} with parameters from config", **kwargs

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -151,7 +151,10 @@ class _ArgumentsConfigTest(config_base.BaseConfig):
 class TestModelArguments:
     """Tests for the `ModelArguments` class."""
 
-    @pytest.mark.skipif(sys.version_info.minor <= 9)
+    @pytest.mark.skipif(
+        sys.version_info.minor <= 9,
+        reason="uses | in type annotations which was added in 3.10",
+    )
     @pytest.mark.filterwarnings("error")
     def test_add_subcommands(self, parser: argparse.ArgumentParser):
         """Test the `add_subcommands` method works without errors / warnings.

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -139,33 +139,19 @@ class TestGetenvBool:
             arguments.getenv_bool(self._variable_name, False)
 
 
-if sys.version_info.minor <= 9:
-    # Using typing instead of | for Python <=3.9
-    # Built-Ins
-    from typing import List, Union
+class _ArgumentsConfigTest(config_base.BaseConfig):
+    """Class for testing `ModelArguments`."""
 
-    class _ArgumentsConfigTest(config_base.BaseConfig):
-        """Class for testing `ModelArguments`."""
-
-        text: str
-        number: Union[float, int]
-        path: pathlib.Path
-        general_list: List[Union[str, int]]
-
-else:
-    # Ignore already defined
-    class _ArgumentsConfigTest(config_base.BaseConfig):  # type: ignore
-        """Class for testing `ModelArguments`."""
-
-        text: str
-        number: float | int
-        path: pathlib.Path
-        general_list: list[str | int]
+    text: str
+    number: float | int
+    path: pathlib.Path
+    general_list: list[str | int]
 
 
 class TestModelArguments:
     """Tests for the `ModelArguments` class."""
 
+    @pytest.mark.skipif(sys.version_info.minor <= 9)
     @pytest.mark.filterwarnings("error")
     def test_add_subcommands(self, parser: argparse.ArgumentParser):
         """Test the `add_subcommands` method works without errors / warnings.

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import argparse
 import os
 import pathlib
+import sys
 
 # Third Party
 import pytest
@@ -138,13 +139,28 @@ class TestGetenvBool:
             arguments.getenv_bool(self._variable_name, False)
 
 
-class _ArgumentsConfigTest(config_base.BaseConfig):
-    """Class for testing `ModelArguments`."""
+if sys.version_info.minor <= 9:
+    # Using typing instead of | for Python <=3.9
+    # Built-Ins
+    from typing import List, Union
 
-    text: str
-    number: float | int
-    path: pathlib.Path
-    general_list: list[str | int]
+    class _ArgumentsConfigTest(config_base.BaseConfig):
+        """Class for testing `ModelArguments`."""
+
+        text: str
+        number: Union[float, int]
+        path: pathlib.Path
+        general_list: List[Union[str, int]]
+
+else:
+    # Ignore already defined
+    class _ArgumentsConfigTest(config_base.BaseConfig):  # type: ignore
+        """Class for testing `ModelArguments`."""
+
+        text: str
+        number: float | int
+        path: pathlib.Path
+        general_list: list[str | int]
 
 
 class TestModelArguments:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -139,13 +139,19 @@ class TestGetenvBool:
             arguments.getenv_bool(self._variable_name, False)
 
 
-class _ArgumentsConfigTest(config_base.BaseConfig):
-    """Class for testing `ModelArguments`."""
+if sys.version_info.minor <= 9:
+    # Creating dummy class because the test is skipped
+    class _ArgumentsConfigTest: ...  # pylint: disable=too-few-public-methods
 
-    text: str
-    number: float | int
-    path: pathlib.Path
-    general_list: list[str | int]
+else:
+    # Ignore already defined
+    class _ArgumentsConfigTest(config_base.BaseConfig):  # type: ignore
+        """Class for testing `ModelArguments`."""
+
+        text: str
+        number: float | int
+        path: pathlib.Path
+        general_list: list[str | int]
 
 
 class TestModelArguments:

--- a/tests/test_arguments.py
+++ b/tests/test_arguments.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 # Built-Ins
+import argparse
 import os
 import pathlib
 
@@ -13,7 +14,7 @@ import pathlib
 import pytest
 
 # Local Imports
-from caf.toolkit import arguments
+from caf.toolkit import arguments, config_base
 
 ##### CONSTANTS #####
 
@@ -37,7 +38,15 @@ CORRECT_ANNOTATIONS = [
     ("<class 'int'>", (int, False, None)),
     ("<class 'str'>", (str, False, None)),
     ("<class 'float'>", (float, False, None)),
+    ("<class 'pathlib.Path'>", (pathlib.Path, False, None)),
+    ("<class 'pathlib._local.Path'>", (pathlib.Path, False, None)),
 ]
+
+
+@pytest.fixture(name="parser")
+def fix_parser() -> argparse.ArgumentParser:
+    """Empty ArgumentParser."""
+    return argparse.ArgumentParser()
 
 
 class TestParseArgDetails:
@@ -127,3 +136,27 @@ class TestGetenvBool:
 
         with pytest.raises(ValueError, match=pattern):
             arguments.getenv_bool(self._variable_name, False)
+
+
+class _ArgumentsConfigTest(config_base.BaseConfig):
+    """Class for testing `ModelArguments`."""
+
+    text: str
+    number: float | int
+    path: pathlib.Path
+    general_list: list[str | int]
+
+
+class TestModelArguments:
+    """Tests for the `ModelArguments` class."""
+
+    @pytest.mark.filterwarnings("error")
+    def test_add_subcommands(self, parser: argparse.ArgumentParser):
+        """Test the `add_subcommands` method works without errors / warnings.
+
+        **Doesn't check the correct sub-commands have been added.**
+        """
+        subparsers = parser.add_subparsers()
+
+        arg_class = arguments.ModelArguments(_ArgumentsConfigTest)
+        arg_class.add_subcommands(subparsers, "test")


### PR DESCRIPTION
# Changes

- Updated `ModelArguments.add_subcommands` to turn off adding arguments or adding config subcommands.
- Added very basic unit test for `ModelArguments.add_subcommands`
- Fixed issues with type annotations containing package and module name e.g. `pathlib._local.Path`

## Issues

- Fixes #165

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [x] Code linting, tests and other workflows pass
