### PR TITLE
[lint] GitHub actions caching package dependencies

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   format:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/documentation-links.yml
+++ b/.github/workflows/documentation-links.yml
@@ -11,6 +11,7 @@ permissions:
 
 jobs:
   documentation-links:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: readthedocs/actions/preview@v1

--- a/.github/workflows/isort.yml
+++ b/.github/workflows/isort.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   format:
+    timeout-minutes: 3
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -24,6 +24,11 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
+          cache-dependency-path: |
+            requirements.txt
+            requirements_dev.txt
+            requirements_sparse.txt
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   lint:
+    timeout-minutes: 3
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ permissions:
 
 jobs:
   deploy:
+    timeout-minutes: 3
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+defaults:
+  timeout-minutes: 2
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 2
+    timeout-minutes: 3
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,6 +20,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        cache: 'pip'
+        cache-dependency-path: |
+          requirements.txt
+          requirements_dev.txt
+          requirements_sparse.txt
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,11 +6,10 @@ on:
   pull_request:
     branches: main
 
-defaults:
-  timeout-minutes: 2
-
 jobs:
   test:
+    timeout-minutes: 2
+
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   test:
-    timeout-minutes: 3
+    timeout-minutes: 5
 
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
# Changes

Updated setup-python action to cache dependencies for linting and tests workflows, the cache is definitely used but not sure it saves much time. Caching can be seen in the outputs on any commits except the first where no cache exists yet.
Added timeout-minutes to tests workflow and you can see it correctly cancelling the action early in [action on commit 977b462](https://github.com/Transport-for-the-North/caf.toolkit/actions/runs/17578000950/job/49927644258?pr=193)
Set timeout to 3 minutes for all workflows, @BenTaylor-TfN any thoughts on a good timeout?

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - NA
- [x] Has documentation (including user guide) been updated - NA
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - NA
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--193.org.readthedocs.build/en/193/

<!-- readthedocs-preview caftoolkit end -->