### PR TITLE
[docs] added link to read the docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ a lot of the useful stuff from
 [NorMITs Demand](https://github.com/Transport-for-the-North/NorMITs-Demand)
 more widely available and easily accessible.
 
+> [!TIP]
+> For more detailed information including a user guide, tutorials and API reference see the full
+> [caf.toolkit documentation](https://caftoolkit.readthedocs.io/en/stable/)
+
 ## Common Analytical Framework
 
 This package is sits within the [Common Analytical Framework (CAF)](https://transport-for-the-north.github.io/caf_homepage/intro.html),


### PR DESCRIPTION
# Changes

Based on some of the flatpack reviews docs seems to be a main concern and I wondered if adding something like this to the top of all READMEs might help.

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--194.org.readthedocs.build/en/194/

<!-- readthedocs-preview caftoolkit end -->