### PR TITLE
[fix] bug in ModelArguments creating configs without CLI arguments

### DIFF
--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -356,9 +356,8 @@ class ModelArguments:
                 "cannot add subcommands if add_arguments and add_config are both False."
             )
 
-        parser = subparsers.add_parser(name, **kwargs)
-
         if add_arguments:
+            parser = subparsers.add_parser(name, **kwargs)
             self.add_arguments(parser)
 
         if self._config and add_config:


### PR DESCRIPTION
# Changes

The `add_subcommands` method incorrectly creates the parser when add_arguments is False.

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass
