### PR TITLE
Made matrix_describe handle DataFrame, long Series, and flat Series

### DIFF
--- a/src/caf/toolkit/pandas_utils/matrices.py
+++ b/src/caf/toolkit/pandas_utils/matrices.py
@@ -442,9 +442,7 @@ def matrix_describe(
                 "Series must have either a 1-level index (flat) or a 2-level MultiIndex (row, col)."
             )
     else:
-        raise TypeError(
-            "matrix must be a pandas DataFrame or a pandas Series"
-        )
+        raise TypeError("matrix must be a pandas DataFrame or a pandas Series")
 
     n_rows, n_cols = grid.shape[0], grid.shape[1]
 


### PR DESCRIPTION
Handles:
- DataFrame (square)
- Series (2-level MI) via unstack()
- Series (1-level) as 1-col grid

Computes same output fields and optional square validation. Existing test cases are passed

Note: New test cases to be written for this change

<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--197.org.readthedocs.build/en/197/

<!-- readthedocs-preview caftoolkit end -->