### PR TITLE
[feat] normalise column names in `read_csv`

### DIFF
--- a/src/caf/toolkit/io.py
+++ b/src/caf/toolkit/io.py
@@ -202,6 +202,9 @@ def _normalise_read_csv(
 ) -> tuple[dict[str, str], _Usecols | None, _Dtype | None, _IndexCol | None]:
     """Produce normalised column names and lookup from original.
 
+    Reads headers only from CSV to quickly obtain current
+    column names and produce normalised lookup.
+
     Parameters
     ----------
     path

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -157,10 +157,15 @@ class TestReadCSV:
 
         pd.testing.assert_frame_equal(data.data, read, check_dtype=False)
 
-    def test_full(self, data: DataFrameResults):
+    @pytest.mark.parametrize("normalise_column_names", [True, False])
+    def test_full(self, data: DataFrameResults, normalise_column_names: bool):
         """Test loading CSV with usecols, dtype and index_col parameters."""
         read = io.read_csv(
-            data.path, usecols=data.columns, dtype=data.dtypes, index_col=data.columns[0]
+            data.path,
+            usecols=data.columns,
+            dtype=data.dtypes,
+            normalise_column_names=normalise_column_names,
+            index_col=data.columns[0],
         )
 
         correct = data.data.set_index(data.columns[0])


### PR DESCRIPTION
# Changes

Optional flag in `read_csv` to normalise column names when reading, normalising does the following:
- Strips whitespace from the ends and converts to lower case
- Replaces spaces with underscores; and
- Removes any characters not in this `abcdefghijklmnopqrstuvwxyz0123456789!#$%£&-.<=>+^_~()`


# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [x] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--199.org.readthedocs.build/en/199/

<!-- readthedocs-preview caftoolkit end -->