### PR TITLE
[lint] ignoring type annotations for *args, **kwargs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,9 +103,11 @@ ignore = [
     "SIM108", # one line if else (flake8-bandit)
     "S311",   # random.random not allowed (flake8-bandit)
     "DOC502", # docstring-extraneous-exception (sometimes necessary)
+    "ANN002", # allow missing type annotations for *args
+    "ANN003", # allow missing type annotations for **kwargs
 ]
 unfixable = [
-    "T20", # print-statements (flake8-print)
+    "T20",  # print-statements (flake8-print)
     "B905", # zip without strict, fix defaults to False
 ]
 
@@ -120,6 +122,9 @@ unfixable = [
     "D205", # allow one-liner docstrings
     "D400", # allow missing first line in docstrings
 ]
+
+[tool.ruff.lint.flake8-annotations]
+suppress-dummy-args = true # ignore missing annotations for _
 
 [tool.ruff.lint.pydocstyle]
 convention = "numpy"

--- a/src/caf/toolkit/arguments.py
+++ b/src/caf/toolkit/arguments.py
@@ -345,7 +345,7 @@ class ModelArguments:
         name: str,
         add_arguments: bool = True,
         add_config: bool = True,
-        **kwargs,  # noqa: ANN003
+        **kwargs,
     ) -> None:
         """Add sub-commands for CLI arguments and config (if possible).
 

--- a/src/caf/toolkit/concurrency/multiprocessing_wrapper.py
+++ b/src/caf/toolkit/concurrency/multiprocessing_wrapper.py
@@ -197,8 +197,8 @@ def wait_for_pool_results(  # noqa: C901
 def _call_order_wrapper(
     index: int,
     func: Callable[..., _T],
-    *args,  # noqa: ANN002
-    **kwargs,  # noqa: ANN003
+    *args,
+    **kwargs,
 ) -> tuple[int, _T]:
     """Wrap a function return values with a calling index.
 

--- a/src/caf/toolkit/cost_utils.py
+++ b/src/caf/toolkit/cost_utils.py
@@ -380,8 +380,8 @@ class CostDistribution:  # noqa: PLW1641
     def from_data_no_bins(
         matrix: np.ndarray,
         cost_matrix: np.ndarray,
-        *args,  # noqa: ANN002
-        **kwargs,  # noqa: ANN003
+        *args,
+        **kwargs,
     ) -> CostDistribution:
         """Convert values and a cost matrix into a CostDistribution.
 
@@ -678,8 +678,8 @@ def normalised_cost_distribution(
 def dynamic_cost_distribution(
     matrix: np.ndarray,
     cost_matrix: np.ndarray,
-    *args,  # noqa: ANN002
-    **kwargs,  # noqa: ANN003
+    *args,
+    **kwargs,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Calculate the distribution of costs across a matrix, using dynamic bins.
 

--- a/src/caf/toolkit/io.py
+++ b/src/caf/toolkit/io.py
@@ -36,7 +36,7 @@ NORMALISED_CHARACTERS = string.ascii_lowercase + string.digits + NORMALISED_PUNT
 class MissingColumnsError(Exception):
     """Raised when columns are missing from input CSV."""
 
-    def __init__(self, name: str, columns: list[str], *args, **kwargs) -> None:  # noqa: ANN002, ANN003
+    def __init__(self, name: str, columns: list[str], *args, **kwargs) -> None:
         self.columns = columns
         cols = " and".join(", ".join(f"'{s}'" for s in columns).rsplit(",", 1))
         msg = f"Columns missing from {name}: {cols}"
@@ -46,8 +46,8 @@ class MissingColumnsError(Exception):
 # # # FUNCTIONS # # #
 def safe_dataframe_to_csv(
     df: pd.DataFrame,
-    *args,  # noqa: ANN002
-    **kwargs,  # noqa: ANN003
+    *args,
+    **kwargs,
 ) -> None:
     """Prompt the user to close a file before saving.
 
@@ -92,7 +92,7 @@ def read_csv(
     path: os.PathLike,
     name: str | None = None,
     normalise_column_names: bool = False,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.DataFrame:
     """Read CSV files, wraps `pandas.read_csv` to perform additional checks.
 
@@ -202,7 +202,7 @@ def _normalise_read_csv(  # noqa: C901
     usecols: _Usecols | None = None,
     dtype: _Dtype | None = None,
     index_col: _IndexCol | None = None,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> tuple[dict[str, str], _Usecols | None, _Dtype | None, _IndexCol | None]:
     """Produce normalised column names and lookup from original.
 
@@ -306,7 +306,7 @@ def _normalise_name(col: str) -> str:
 def read_csv_matrix(
     path: os.PathLike,
     format_: Literal["square", "long"] | None = None,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.DataFrame:
     """Read matrix CSV in the square or long format.
 

--- a/src/caf/toolkit/log_helpers.py
+++ b/src/caf/toolkit/log_helpers.py
@@ -567,7 +567,7 @@ class TemporaryLogFile:
         logger: logging.Logger,
         log_file: os.PathLike,
         base_log_file: os.PathLike | None = None,
-        **kwargs,  # noqa: ANN003
+        **kwargs,
     ) -> None:
         self.logger = logger
         self.log_file = log_file

--- a/src/caf/toolkit/pandas_utils/df_handling.py
+++ b/src/caf/toolkit/pandas_utils/df_handling.py
@@ -83,7 +83,7 @@ def reindex_cols(
     columns: list[str],
     throw_error: bool = True,
     dataframe_name: str = "the given dataframe",
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Reindexes a pandas DataFrame. Will throw error if columns aren't in `df`.
@@ -140,7 +140,7 @@ def reindex_rows_and_cols(
     index: list[Any],
     columns: list[Any],
     fill_value: Any = np.nan,  # noqa: ANN401
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Reindex a pandas DataFrame, making sure index/col types don't clash.
@@ -193,7 +193,7 @@ def reindex_and_groupby_sum(
     index_cols: list[str],
     value_cols: list[str],
     throw_error: bool = True,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.DataFrame:
     """
     Reindexes and groups a pandas DataFrame.
@@ -677,7 +677,7 @@ def wide_to_long_infill(
     return stacked
 
 
-def long_df_to_wide_ndarray(*args, **kwargs) -> np.ndarray:  # noqa: ANN002, ANN003
+def long_df_to_wide_ndarray(*args, **kwargs) -> np.ndarray:
     """Convert a DataFrame from long to wide format, infilling missing values.
 
     Similar to the `long_to_wide_infill()` function, but returns a numpy array

--- a/src/caf/toolkit/pandas_utils/utility.py
+++ b/src/caf/toolkit/pandas_utils/utility.py
@@ -66,7 +66,7 @@ def to_numeric(
     arg: np.ndarray,
     errors: Literal["ignore", "raise", "coerce"] = "raise",
     downcast: Literal["integer", "signed", "unsigned", "float"] | None = None,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> np.ndarray: ...
 
 
@@ -75,7 +75,7 @@ def to_numeric(
     arg: pd.Index,
     errors: Literal["ignore", "raise", "coerce"] = "raise",
     downcast: Literal["integer", "signed", "unsigned", "float"] | None = None,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.Index: ...
 
 
@@ -84,7 +84,7 @@ def to_numeric(
     arg: pd.Series,
     errors: Literal["ignore", "raise", "coerce"] = "raise",
     downcast: Literal["integer", "signed", "unsigned", "float"] | None = None,
-    **kwargs,  # noqa: ANN003
+    **kwargs,
 ) -> pd.Series: ...
 
 

--- a/tests/concurrency/test_multiprocessing.py
+++ b/tests/concurrency/test_multiprocessing.py
@@ -145,12 +145,12 @@ class TestMultiprocessErrors:
     """Tests caf.toolkit.concurrency.multiprocess error production."""
 
     @staticmethod
-    def error_throw_function(*_, **__) -> NoReturn:  # noqa: ANN002, ANN003
+    def error_throw_function(*_, **__) -> NoReturn:
         """Throw an error."""
         raise OSError
 
     @staticmethod
-    def wait_function(*_, **__) -> None:  # noqa: ANN002, ANN003
+    def wait_function(*_, **__) -> None:
         """Wait for timeout error."""
         time.sleep(100)
 

--- a/tests/test_log_helpers.py
+++ b/tests/test_log_helpers.py
@@ -200,7 +200,7 @@ class TestGitDescribe:
         """Test function correctly returns the string result if command is successful."""
         describe = "v1.0-1-abc123"
 
-        def dummy_run(*_, **_kw) -> subprocess.CompletedProcess:  # noqa:ANN002,ANN003
+        def dummy_run(*_, **_kw) -> subprocess.CompletedProcess:
             return subprocess.CompletedProcess("", 0, stdout=describe.encode())
 
         monkeypatch.setattr(subprocess, "run", dummy_run)
@@ -210,7 +210,7 @@ class TestGitDescribe:
     def test_invalid(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Test None is returned whenever the subprocess returns a non-zero code."""
 
-        def dummy_run(*_, **_kw) -> subprocess.CompletedProcess:  # noqa:ANN002,ANN003
+        def dummy_run(*_, **_kw) -> subprocess.CompletedProcess:
             return subprocess.CompletedProcess("", 1)
 
         monkeypatch.setattr(subprocess, "run", dummy_run)

--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -62,7 +62,7 @@ class NumpyMatrixResults:
     def input_kwargs(
         self,
         check_shapes: bool = True,
-        **kwargs,  # noqa: ANN003
+        **kwargs,
     ) -> dict[str, Any]:
         """Return a dictionary of key-word arguments."""
         return {
@@ -313,7 +313,7 @@ class PandasMatrixResults:
     def input_kwargs(
         self,
         check_totals: bool = True,
-        **kwargs,  # noqa: ANN003
+        **kwargs,
     ) -> dict[str, Any]:
         """Return a dictionary of key-word arguments."""
         kwargs = (
@@ -376,7 +376,7 @@ class PandasLongMatrixResults:
     def input_kwargs(
         self,
         check_totals: bool = True,
-        **kwargs,  # noqa: ANN003
+        **kwargs,
     ) -> dict[str, Any]:
         """Return a dictionary of key-word arguments."""
         kwargs = (


### PR DESCRIPTION
# Changes

Ignoring ruff rules for type annotations on *args, and **kwargs parameters. Removed noqa comments which are now unnecessary.

@Kieran-Fishwick-TfN, @isaac-tfn what are your thoughts on these rules should we disable both or just disable the keyword one and leave *args because I can see it being more useful to type that one?

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--206.org.readthedocs.build/en/206/

<!-- readthedocs-preview caftoolkit end -->