### PR TITLE
[fix] BaseConfig convert to Path for file open

### DIFF
--- a/src/caf/toolkit/config_base.py
+++ b/src/caf/toolkit/config_base.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import datetime as dt
 import textwrap
 from dataclasses import asdict, is_dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, overload
 
 # Third Party
@@ -14,7 +15,6 @@ import pydantic_core
 import strictyaml
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import Any, Self
 
 # # # CONSTANTS # # #
@@ -116,6 +116,7 @@ class BaseConfig(pydantic.BaseModel):
             Instance of class with attributes filled in from
             the YAML data.
         """
+        path = Path(path)
         with path.open("rt", encoding="utf-8") as file:
             text = file.read()
         return cls.from_yaml(text)
@@ -332,5 +333,6 @@ def write_config(
         comment_lines = [i if i.startswith("#") else f"# {i}" for i in comment_lines]
         yaml = "\n".join([*comment_lines, yaml])
 
+    path = Path(path)
     with path.open("wt", encoding="utf-8") as file:
         file.write(yaml)

--- a/tests/test_config_base.py
+++ b/tests/test_config_base.py
@@ -224,6 +224,12 @@ class TestYaml:
         basic.save_yaml(file_path)
         assert ConfigTestClass.load_yaml(file_path) == basic
 
+    def test_save_load_str(self, basic: ConfigTestClass, path: Path) -> None:
+        """Test saving to a YAML and reading works when path is string."""
+        file_path = str(path / "save_test.yml")
+        basic.save_yaml(file_path)
+        assert ConfigTestClass.load_yaml(file_path) == basic
+
 
 class TestExample:
     """Test writing the example file is correct."""


### PR DESCRIPTION


# Changes

Previously switched to using `path.open` instead of built-in open function which will not work if path is a str. The type annotation specifies it should be a Path object (not a string) but if people don't use MyPy they may not notice this and it's simple enough to attempt to convert the object to Path before calling open so it will work with strings even if we don't encourage it.

Added unit test which fails before this change is made but passes after.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--209.org.readthedocs.build/en/209/

<!-- readthedocs-preview caftoolkit end -->