### PR TITLE
Fix: ignore false positive bug in MyPy and PyLint #210

### DIFF
--- a/src/caf/toolkit/pandas_utils/random.py
+++ b/src/caf/toolkit/pandas_utils/random.py
@@ -167,7 +167,7 @@ class UniqueIdGenerator(DataGenerator):
             Generated data.
         """
         del generator
-        values = np.arange(start=self.starting_val, stop=self.starting_val + self.length)
+        values = np.arange(start=self.starting_val, stop=self.starting_val + self.length)  # type: ignore[call-overload]
         return pd.Series(values, name=self.name)
 
 

--- a/src/caf/toolkit/translation.py
+++ b/src/caf/toolkit/translation.py
@@ -100,8 +100,8 @@ def _convert_dtypes(
     dtype_max: np.floating | int
     dtype_min: np.floating | int
     if np.issubdtype(to_type, np.floating):
-        dtype_max = np.finfo(to_type).max
-        dtype_min = np.finfo(to_type).min
+        dtype_max = np.finfo(to_type).max  # #210 pylint: disable=no-member
+        dtype_min = np.finfo(to_type).min  # #210 pylint: disable=no-member
     elif np.issubdtype(to_type, np.integer):
         dtype_max = np.iinfo(to_type).max
         dtype_min = np.iinfo(to_type).min


### PR DESCRIPTION
# Changes

Ignores false positives from MyPy and PyLint which seem to be bugs with them and numpy v2.4.1, #210 tracks this issue but should stay open so we can removed the ignore comments once the bug is fixed.

# Tasks

- [ ] Have unittests been added (testing individual functions and their edge cases)
- [ ] Has documentation (including user guide) been updated
- [ ] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--211.org.readthedocs.build/en/211/

<!-- readthedocs-preview caftoolkit end -->