### PR TITLE
Fix: support UTF-8 encoding in log file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required libraries
 numpy>=1.19.0
-pandas>=2.0.0
+pandas>=2.0.0,<3
 tqdm>=4.50.2
 pydantic>=2.5.0
 strictyaml>=1.6

--- a/src/caf/toolkit/log_helpers.py
+++ b/src/caf/toolkit/log_helpers.py
@@ -757,7 +757,7 @@ def get_logger(
     `get_file_handler()`
     `get_console_handler()`
     """
-    log_handlers = list()
+    log_handlers: list[logging.Handler] = list()
     if log_file_path is not None:
         log_handlers.append(get_file_handler(log_file_path))
 

--- a/src/caf/toolkit/log_helpers.py
+++ b/src/caf/toolkit/log_helpers.py
@@ -833,7 +833,7 @@ def get_file_handler(
     console_handler:
         A logging.StreamHandler object using the format in ch_format.
     """
-    handler = logging.FileHandler(log_file)
+    handler = logging.FileHandler(log_file, encoding="utf-8")
     handler.setLevel(log_level)
     handler.setFormatter(logging.Formatter(fh_format, datefmt=datetime_format))
     return handler

--- a/src/caf/toolkit/log_helpers.py
+++ b/src/caf/toolkit/log_helpers.py
@@ -809,7 +809,7 @@ def get_file_handler(
     datetime_format: str = DEFAULT_FILE_DATETIME,
     log_level: int = logging.DEBUG,
 ) -> logging.FileHandler:
-    """Create a console handles for a logger.
+    """Create a file handler for a logger.
 
     Parameters
     ----------

--- a/src/caf/toolkit/log_helpers.py
+++ b/src/caf/toolkit/log_helpers.py
@@ -808,7 +808,7 @@ def get_file_handler(
     fh_format: str = DEFAULT_FILE_FORMAT,
     datetime_format: str = DEFAULT_FILE_DATETIME,
     log_level: int = logging.DEBUG,
-) -> logging.StreamHandler:
+) -> logging.FileHandler:
     """Create a console handles for a logger.
 
     Parameters
@@ -827,11 +827,6 @@ def get_file_handler(
 
     log_level:
         The logging level to give to the FileHandler.
-
-    Returns
-    -------
-    console_handler:
-        A logging.StreamHandler object using the format in ch_format.
     """
     handler = logging.FileHandler(log_file, encoding="utf-8")
     handler.setLevel(log_level)

--- a/tests/test_log_helpers.py
+++ b/tests/test_log_helpers.py
@@ -435,7 +435,10 @@ class TestLogHelper:
 
         assert len(log.logger.handlers) == 0, "handlers not cleaned up"
 
-    def test_basic_file(self, tmp_path: pathlib.Path, log_init: LogInitDetails) -> None:
+    @pytest.mark.parametrize("msg", ["no emojis", "emojis 👍😀"])
+    def test_basic_file(
+        self, tmp_path: pathlib.Path, log_init: LogInitDetails, msg: str
+    ) -> None:
         """Test logging to file within `with` statement.
 
         Tests all log calls within `with` statement are logged to file
@@ -452,11 +455,13 @@ class TestLogHelper:
             log_file=log_file,
             warning_capture=False,
         ):
-            messages = _log_messages(log, "testing level {level} - test basic file")
+            messages = _log_messages(log, f"testing level {{level}} - test basic file - {msg}")
 
         # Messages logged after the log helper class has
         # cleaned up so shouldn't be saved to file
-        unlogged_messages = _log_messages(log, "not logging this message for level {level}")
+        unlogged_messages = _log_messages(
+            log, f"not logging this message for level {{level}} - {msg}"
+        )
 
         text = _load_log(log_file)
 

--- a/tests/test_log_helpers.py
+++ b/tests/test_log_helpers.py
@@ -435,9 +435,9 @@ class TestLogHelper:
 
         assert len(log.logger.handlers) == 0, "handlers not cleaned up"
 
-    @pytest.mark.parametrize("msg", ["no emojis", "emojis 👍😀"])
+    @pytest.mark.parametrize("message", ["no emojis", "emojis 👍😀"])
     def test_basic_file(
-        self, tmp_path: pathlib.Path, log_init: LogInitDetails, msg: str
+        self, tmp_path: pathlib.Path, log_init: LogInitDetails, message: str
     ) -> None:
         """Test logging to file within `with` statement.
 
@@ -455,12 +455,14 @@ class TestLogHelper:
             log_file=log_file,
             warning_capture=False,
         ):
-            messages = _log_messages(log, f"testing level {{level}} - test basic file - {msg}")
+            messages = _log_messages(
+                log, f"testing level {{level}} - test basic file - {message}"
+            )
 
         # Messages logged after the log helper class has
         # cleaned up so shouldn't be saved to file
         unlogged_messages = _log_messages(
-            log, f"not logging this message for level {{level}} - {msg}"
+            log, f"not logging this message for level {{level}} - {message}"
         )
 
         text = _load_log(log_file)


### PR DESCRIPTION
# Changes

Added UTF-8 encoding into logging `FileHandler` so emojis can be handled in log messages, otherwise logger doesn't include messages in log file if they use UTF specific characters.

The main reason for this is that paths to sync'd MS Teams folders can contain emojis and without this fix these messages would be missed from the log file.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated - no
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - no
- [x] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--212.org.readthedocs.build/en/212/

<!-- readthedocs-preview caftoolkit end -->