### PR TITLE
[fix]: Added error checks to `mark_internal_external`

### DIFF
--- a/src/caf/toolkit/pandas_utils/matrices.py
+++ b/src/caf/toolkit/pandas_utils/matrices.py
@@ -580,15 +580,35 @@ def mark_internal_external(
     -------
     pd.DataFrame
         Matrix with internal and external trips marked.
+
+    Raises
+    ------
+    ValueError:
+        If the origin and destination columns are not in the matrix.
+        If the origin and destination columns have different dtypes.
+        If no internal zones are found in either the origin or destination columns.
     """
     if not {origin_col, destination_col}.issubset(matrix.columns):
         raise ValueError(
-            f"Given '{origin_col}' and '{destination_col}' but matrix has columns {list(matrix.columns)}"  # noqa: E501
+            f"Given '{origin_col}' and '{destination_col}' but matrix has "
+            f"columns {list(matrix.columns)}"
+        )
+
+    if matrix[origin_col].dtype != matrix[destination_col].dtype:
+        raise ValueError(
+            f"Origin and destination columns must have the same dtype, but got "
+            f"{matrix[origin_col].dtype} and {matrix[destination_col].dtype}"
         )
 
     marked_matrix = matrix.copy()
     origin_in = marked_matrix[origin_col].isin(internal_zones)
     dest_in = marked_matrix[destination_col].isin(internal_zones)
+
+    if not origin_in.any() and not dest_in.any():
+        raise ValueError(
+            "No internal zones found in either origin or destination columns. "
+            "Are the datatypes the same?"
+        )
 
     # Everything should be marked, but default to NA if anything weird happens
     marked_matrix[zone_class_col] = pd.NA

--- a/src/caf/toolkit/pandas_utils/matrices.py
+++ b/src/caf/toolkit/pandas_utils/matrices.py
@@ -604,10 +604,21 @@ def mark_internal_external(
     origin_in = marked_matrix[origin_col].isin(internal_zones)
     dest_in = marked_matrix[destination_col].isin(internal_zones)
 
+    # Check for signs of deeper issues and raise
     if not origin_in.any() and not dest_in.any():
         raise ValueError(
             "No internal zones found in either origin or destination columns. "
             "Are the datatypes the same?"
+        )
+
+    if (not origin_in.any()) ^ (not dest_in.any()):
+        if origin_in.any():
+            columns = ("origin", "destination")
+        else:
+            columns = ("destination", "origin")
+        warnings.warn(
+            f"Internal zones only found in {columns[0]} column, not in {columns[1]} column",
+            stacklevel=2,
         )
 
     # Everything should be marked, but default to NA if anything weird happens

--- a/tests/pandas_utils/test_matrices.py
+++ b/tests/pandas_utils/test_matrices.py
@@ -786,6 +786,16 @@ class TestMarkInternalExternal:
                 test_matrix, internal_zones, origin_col="from_zone", destination_col="to_zone"
             )
 
+    def test_dtype_mismatch_raises(self) -> None:
+        """Test that mismatched dtypes in origin/destination raise ValueError."""
+        test_matrix = pd.DataFrame({"origin": [1, 2], "destination": ["1", "2"]})
+        internal_zones = [1]
+
+        with pytest.raises(
+            ValueError, match="Origin and destination columns must have the same dtype"
+        ):
+            pd_utils.matrices.mark_internal_external(test_matrix, internal_zones)
+
     def test_preserves_original_data(self, matrix: pd.DataFrame) -> None:
         """Test that the function preserves original data columns."""
         internal_zones = [1, 2]
@@ -849,10 +859,12 @@ class TestMarkInternalExternal:
                 "trips": [100, 50],
             }
         )
-        internal_zones = []
-        result = pd_utils.matrices.mark_internal_external(
-            test_matrix, internal_zones, keep_ee=True, zone_class_col="zone_class"
-        )
+        internal_zones: list = []
 
-        # All trips should be external-external
-        assert (result["zone_class"] == "EE").all()
+        with pytest.raises(
+            ValueError,
+            match="No internal zones found in either origin or destination columns",
+        ):
+            pd_utils.matrices.mark_internal_external(
+                test_matrix, internal_zones, keep_ee=True, zone_class_col="zone_class"
+            )

--- a/tests/pandas_utils/test_matrices.py
+++ b/tests/pandas_utils/test_matrices.py
@@ -796,6 +796,19 @@ class TestMarkInternalExternal:
         ):
             pd_utils.matrices.mark_internal_external(test_matrix, internal_zones)
 
+    def test_single_side_internal_zones_warns(self) -> None:
+        """If internal zones are only present in origin OR destination, a warning is raised."""
+        test_matrix = pd.DataFrame(
+            {"origin": [1, 2], "destination": [3, 3], "trips": [10, 20]}
+        )
+        internal_zones = [1]
+
+        with pytest.warns(
+            UserWarning,
+            match="Internal zones only found in origin column, not in destination column",
+        ):
+            pd_utils.matrices.mark_internal_external(test_matrix, internal_zones)
+
     def test_preserves_original_data(self, matrix: pd.DataFrame) -> None:
         """Test that the function preserves original data columns."""
         internal_zones = [1, 2]


### PR DESCRIPTION
# Changes

Added 2 error checks to `mark_internal_external`.
- If the origin and destination columns have different dtypes.
- If no internal zones are found in either the origin or destination columns.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases)
- [x] Has documentation (including user guide) been updated
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt`
- [x] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--216.org.readthedocs.build/en/216/

<!-- readthedocs-preview caftoolkit end -->