### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/typing.yml
+++ b/.github/workflows/typing.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/3](https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/3)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (including `lint`) unless overridden.  
For this workflow, the minimal required permission is:

- `contents: read` (needed for `actions/checkout` to read repository contents)

Best single change: in `.github/workflows/typing.yml`, insert:

```yml
permissions:
  contents: read
```

directly after the workflow triggers (`on:` block) and before `jobs:`. No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--222.org.readthedocs.build/en/222/

<!-- readthedocs-preview caftoolkit end -->