### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 5


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/2](https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so all jobs inherit least-privilege token access.  
Best single fix here: add at workflow root (near `name` / `on`) with `contents: read`, which is the minimal baseline CodeQL recommends and is sufficient for checkout and test execution in this file.

**File to edit:** `.github/workflows/tests.yml`  
**Change region:** top-level section before `jobs:`  
**What to add:**  
```yml
permissions:
  contents: read
```
No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--223.org.readthedocs.build/en/223/

<!-- readthedocs-preview caftoolkit end -->