### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: main
 
+permissions:
+  contents: read
+
 jobs:
   lint:
 


### PR DESCRIPTION
Potential fix for [https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/1](https://github.com/Transport-for-the-North/caf.toolkit/security/code-scanning/1)

Add an explicit `permissions` block to the workflow so `GITHUB_TOKEN` is minimally scoped.  
Best fix here: define it at the workflow root (after `on:` and before `jobs:`) as:

- `contents: read`

This preserves existing functionality (`actions/checkout` and linting only need read access) and applies consistently to all jobs unless overridden later.

**File to edit:** `.github/workflows/linting.yml`  
**Change region:** insert a new top-level `permissions:` section between the trigger block and `jobs:`.

No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--224.org.readthedocs.build/en/224/

<!-- readthedocs-preview caftoolkit end -->