### PR TITLE
CI: dependabot config for major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,25 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 18 * *"
+    allow:
+      # Only allow major version updates to reduce noise from minor/patch updates
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
+      # Allow minor versions for caf packages to ensure new versions are tested more often
+      - dependency-name: "caf.*"
+        update-types:
+          - "version-update:semver-minor"
+    # If you only want security update PRs, set this to 0
+    open-pull-requests-limit: 3
+
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "cron"
+      cronjob: "0 0 28 * *"
+    open-pull-requests-limit: 1

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "cron"
-      cronjob: "0 0 18 * *"
+      cronjob: "0 0 19 * *"
     allow:
       # Only allow major version updates to reduce noise from minor/patch updates
       - dependency-name: "*"


### PR DESCRIPTION
# Changes

> [!IMPORTANT]
> Using tomorrow's date for testing purposes, will change this to the 28th once we've confirmed it works.

Added dependabot config for major versions of Python packages and minor versions of CAF packages. Also, check on github actions.

# Tasks

- [x] Have unittests been added (testing individual functions and their edge cases) - No
- [x] Has documentation (including user guide) been updated - No
- [x] Have new dependencies been added (or changed) in relevant `requirements.txt` - No
- [ ] Code linting, tests and other workflows pass


<!-- readthedocs-preview caftoolkit start -->
----
📚 Documentation preview 📚: https://caftoolkit--231.org.readthedocs.build/en/231/

<!-- readthedocs-preview caftoolkit end -->